### PR TITLE
Add core loader, CPTs, admin menu, and REST endpoints

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -1,0 +1,2 @@
+/* VemComer Admin base */
+.wrap h1 { margin-bottom: 12px; }

--- a/assets/css/frontend.css
+++ b/assets/css/frontend.css
@@ -1,0 +1,1 @@
+/* VemComer Frontend base */

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -1,0 +1,2 @@
+// VemComer Admin base
+console.debug('[VemComer] Admin carregado');

--- a/assets/js/frontend.js
+++ b/assets/js/frontend.js
@@ -1,0 +1,1 @@
+// VemComer Frontend base

--- a/inc/class-vc-admin-menu.php
+++ b/inc/class-vc-admin-menu.php
@@ -1,0 +1,33 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) { exit; }
+
+class VC_Admin_Menu {
+    public function init(): void {
+        add_action( 'admin_menu', [ $this, 'register_menu' ] );
+    }
+
+    public function register_menu(): void {
+        add_menu_page(
+            'VemComer',
+            'VemComer',
+            'manage_options',
+            'vemcomer-root',
+            [ $this, 'render_root' ],
+            'dashicons-store'
+        );
+
+        add_submenu_page( 'vemcomer-root', 'Produtos', 'Produtos', 'edit_posts', 'edit.php?post_type=' . VC_CPT_Produto::SLUG );
+        add_submenu_page( 'vemcomer-root', 'Pedidos', 'Pedidos', 'edit_posts', 'edit.php?post_type=' . VC_CPT_Pedido::SLUG );
+        add_submenu_page( 'vemcomer-root', 'Configurações', 'Configurações', 'manage_options', 'vemcomer-settings', [ $this, 'render_settings' ] );
+    }
+
+    public function render_root(): void {
+        echo '<div class="wrap"><h1>VemComer</h1><p>Bem-vindo ao core do marketplace.</p></div>';
+    }
+
+    public function render_settings(): void {
+        wp_enqueue_style( 'vemcomer-admin' );
+        wp_enqueue_script( 'vemcomer-admin' );
+        echo '<div class="wrap"><h1>Configurações</h1><p>Em breve: chaves de API, loja, etc.</p></div>';
+    }
+}

--- a/inc/class-vc-cpt-pedido.php
+++ b/inc/class-vc-cpt-pedido.php
@@ -1,0 +1,53 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) { exit; }
+
+class VC_CPT_Pedido {
+    const SLUG = 'vc_pedido';
+
+    public function init(): void {
+        add_action( 'init', [ $this, 'register_cpt' ] );
+        add_action( 'add_meta_boxes', [ $this, 'metaboxes' ] );
+        add_action( 'save_post_' . self::SLUG, [ $this, 'save_meta' ] );
+    }
+
+    public function register_cpt(): void {
+        $labels = [ 'name' => 'Pedidos', 'singular_name' => 'Pedido' ];
+        $args = [
+            'labels' => $labels,
+            'public' => false,
+            'show_ui' => true,
+            'show_in_menu' => false,
+            'supports' => [ 'title' ],
+            'show_in_rest' => true,
+        ];
+        register_post_type( self::SLUG, $args );
+    }
+
+    public function metaboxes(): void {
+        add_meta_box( 'vc_pedido_info', 'Informações do Pedido', [ $this, 'render_info' ], self::SLUG, 'normal' );
+    }
+
+    public function render_info( $post ): void {
+        $itens = (array) get_post_meta( $post->ID, '_vc_itens', true );
+        $total = (string) get_post_meta( $post->ID, '_vc_total', true );
+        echo '<p><strong>Itens</strong></p>';
+        echo '<textarea name="vc_itens" class="widefat" rows="6">' . esc_textarea( wp_json_encode( $itens ) ) . '</textarea>';
+        echo '<p><strong>Total</strong></p>';
+        echo '<input type="text" name="vc_total" class="widefat" value="' . esc_attr( $total ) . '" />';
+        nonce_field( 'vc_pedido_nonce', 'vc_pedido_nonce_field' );
+    }
+
+    public function save_meta( int $post_id ): void {
+        if ( ! isset( $_POST['vc_pedido_nonce_field'] ) || ! wp_verify_nonce( $_POST['vc_pedido_nonce_field'], 'vc_pedido_nonce' ) ) {
+            return;
+        }
+        if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) { return; }
+        if ( ! current_user_can( 'edit_post', $post_id ) ) { return; }
+
+        $itens = isset( $_POST['vc_itens'] ) ? json_decode( wp_unslash( $_POST['vc_itens'] ), true ) : [];
+        if ( ! is_array( $itens ) ) { $itens = []; }
+        $total = isset( $_POST['vc_total'] ) ? vc_sanitize_money( $_POST['vc_total'] ) : '';
+        update_post_meta( $post_id, '_vc_itens', $itens );
+        update_post_meta( $post_id, '_vc_total', $total );
+    }
+}

--- a/inc/class-vc-cpt-produto.php
+++ b/inc/class-vc-cpt-produto.php
@@ -1,0 +1,59 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) { exit; }
+
+class VC_CPT_Produto {
+    const SLUG = 'vc_produto';
+
+    public function init(): void {
+        add_action( 'init', [ $this, 'register_cpt' ] );
+        add_action( 'init', [ $this, 'register_taxonomies' ] );
+        add_action( 'add_meta_boxes', [ $this, 'metaboxes' ] );
+        add_action( 'save_post_' . self::SLUG, [ $this, 'save_meta' ] );
+    }
+
+    public function register_cpt(): void {
+        $labels = [
+            'name' => 'Produtos',
+            'singular_name' => 'Produto',
+        ];
+        $args = [
+            'labels' => $labels,
+            'public' => true,
+            'show_in_menu' => false,
+            'supports' => [ 'title', 'editor', 'thumbnail' ],
+            'show_in_rest' => true,
+        ];
+        register_post_type( self::SLUG, $args );
+    }
+
+    public function register_taxonomies(): void {
+        register_taxonomy( 'vc_categoria', self::SLUG, [
+            'label' => 'Categorias',
+            'public' => true,
+            'hierarchical' => true,
+            'show_in_rest' => true,
+        ] );
+    }
+
+    public function metaboxes(): void {
+        add_meta_box( 'vc_prod_preco', 'Preço', [ $this, 'render_preco' ], self::SLUG, 'side' );
+    }
+
+    public function render_preco( $post ): void {
+        $value = get_post_meta( $post->ID, '_vc_preco', true );
+        echo '<label for="vc_preco">Preço</label>';
+        echo '<input type="text" id="vc_preco" name="vc_preco" value="' . esc_attr( $value ) . '" class="widefat" />';
+        nonce_field( 'vc_preco_nonce', 'vc_preco_nonce_field' );
+    }
+
+    public function save_meta( int $post_id ): void {
+        if ( ! isset( $_POST['vc_preco_nonce_field'] ) || ! wp_verify_nonce( $_POST['vc_preco_nonce_field'], 'vc_preco_nonce' ) ) {
+            return;
+        }
+        if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) { return; }
+        if ( ! current_user_can( 'edit_post', $post_id ) ) { return; }
+
+        $preco = isset( $_POST['vc_preco'] ) ? vc_sanitize_money( $_POST['vc_preco'] ) : '';
+        update_post_meta( $post_id, '_vc_preco', $preco );
+    }
+}

--- a/inc/class-vc-loader.php
+++ b/inc/class-vc-loader.php
@@ -1,0 +1,18 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) { exit; }
+
+class VC_Loader {
+    public function init(): void {
+        add_action( 'init', [ $this, 'register_assets' ] );
+    }
+
+    public function register_assets(): void {
+        // Admin
+        wp_register_style( 'vemcomer-admin', VEMCOMER_CORE_URL . 'assets/css/admin.css', [], VEMCOMER_CORE_VERSION );
+        wp_register_script( 'vemcomer-admin', VEMCOMER_CORE_URL . 'assets/js/admin.js', [ 'wp-element' ], VEMCOMER_CORE_VERSION, true );
+
+        // Frontend
+        wp_register_style( 'vemcomer-front', VEMCOMER_CORE_URL . 'assets/css/frontend.css', [], VEMCOMER_CORE_VERSION );
+        wp_register_script( 'vemcomer-front', VEMCOMER_CORE_URL . 'assets/js/frontend.js', [ 'wp-element' ], VEMCOMER_CORE_VERSION, true );
+    }
+}

--- a/inc/class-vc-rest.php
+++ b/inc/class-vc-rest.php
@@ -1,0 +1,61 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) { exit; }
+
+class VC_REST {
+    public function init(): void {
+        add_action( 'rest_api_init', [ $this, 'routes' ] );
+    }
+
+    public function routes(): void {
+        register_rest_route( 'vemcomer/v1', '/produtos', [
+            'methods'  => 'GET',
+            'callback' => [ $this, 'get_produtos' ],
+            'permission_callback' => '__return_true',
+        ] );
+
+        register_rest_route( 'vemcomer/v1', '/pedidos', [
+            'methods'  => 'POST',
+            'callback' => [ $this, 'create_pedido' ],
+            'permission_callback' => function () { return current_user_can( 'edit_posts' ); },
+        ] );
+    }
+
+    public function get_produtos( WP_REST_Request $request ) {
+        $q = new WP_Query([
+            'post_type' => VC_CPT_Produto::SLUG,
+            'posts_per_page' => 50,
+            'no_found_rows' => true,
+        ]);
+        $items = [];
+        foreach ( $q->posts as $p ) {
+            $items[] = [
+                'id' => $p->ID,
+                'title' => get_the_title( $p ),
+                'price' => get_post_meta( $p->ID, '_vc_preco', true ),
+            ];
+        }
+        return rest_ensure_response( $items );
+    }
+
+    public function create_pedido( WP_REST_Request $request ) {
+        $params = $request->get_json_params();
+        $itens = isset( $params['itens'] ) && is_array( $params['itens'] ) ? $params['itens'] : [];
+        $total = isset( $params['total'] ) ? vc_sanitize_money( $params['total'] ) : '0';
+
+        $post_id = wp_insert_post([
+            'post_type' => VC_CPT_Pedido::SLUG,
+            'post_title' => 'Pedido ' . wp_date( 'Y-m-d H:i:s' ),
+            'post_status' => 'publish',
+        ]);
+        if ( is_wp_error( $post_id ) ) {
+            return new WP_Error( 'vc_pedido_error', 'Não foi possível criar o pedido.', [ 'status' => 500 ] );
+        }
+        update_post_meta( $post_id, '_vc_itens', $itens );
+        update_post_meta( $post_id, '_vc_total', $total );
+
+        return rest_ensure_response([
+            'id' => $post_id,
+            'total' => $total,
+        ]);
+    }
+}

--- a/inc/helpers-sanitize.php
+++ b/inc/helpers-sanitize.php
@@ -1,0 +1,16 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) { exit; }
+
+function vc_sanitize_text( $value ): string {
+    return sanitize_text_field( (string) $value );
+}
+
+function vc_sanitize_money( $value ): string {
+    // Mantém somente dígitos e separadores de decimal/com milhar comuns
+    $value = preg_replace( '/[^0-9.,]/', '', (string) $value );
+    return (string) $value;
+}
+
+function vc_esc_html( $value ): string {
+    return esc_html( (string) $value );
+}


### PR DESCRIPTION
## Summary
- replace plugin bootstrap with lightweight loader that registers core classes and autoloads VC_ classes
- add helpers, loader, CPT, admin menu, and REST classes to encapsulate functionality
- scaffold base admin/frontend assets for future customization

## Testing
- php -l vemcomer-core.php
- php -l inc/class-vc-loader.php
- php -l inc/class-vc-cpt-produto.php
- php -l inc/class-vc-cpt-pedido.php
- php -l inc/class-vc-admin-menu.php
- php -l inc/class-vc-rest.php
- php -l inc/helpers-sanitize.php

------
https://chatgpt.com/codex/tasks/task_b_68df460b6794832b93310805ad0aaf4e