### PR TITLE
Add restaurant and menu item CPTs and REST endpoints

### DIFF
--- a/inc/Admin/Menu_Restaurant.php
+++ b/inc/Admin/Menu_Restaurant.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Menu_Restaurant — Submenus de Admin para Restaurantes e Cardápio
+ * @package VemComerCore
+ */
+
+namespace VC\Admin;
+
+use VC\Model\CPT_Restaurant;
+use VC\Model\CPT_MenuItem;
+
+if ( ! defined( 'ABSPATH' ) ) { exit; }
+
+class Menu_Restaurant {
+    public function init(): void {
+        add_action( 'admin_menu', [ $this, 'register_menu' ] );
+    }
+
+    public function register_menu(): void {
+        // Dependemos do menu principal 'vemcomer-root' criado por VC_Admin_Menu do pacote 1
+        add_submenu_page( 'vemcomer-root', __( 'Restaurantes', 'vemcomer' ), __( 'Restaurantes', 'vemcomer' ), 'edit_posts', 'edit.php?post_type=' . CPT_Restaurant::SLUG );
+        add_submenu_page( 'vemcomer-root', __( 'Cardápio', 'vemcomer' ), __( 'Cardápio', 'vemcomer' ), 'edit_posts', 'edit.php?post_type=' . CPT_MenuItem::SLUG );
+    }
+}

--- a/inc/Model/CPT_MenuItem.php
+++ b/inc/Model/CPT_MenuItem.php
@@ -1,0 +1,130 @@
+<?php
+/**
+ * CPT_MenuItem — Custom Post Type "Menu Item" (Itens do Cardápio)
+ * @package VemComerCore
+ */
+
+namespace VC\Model;
+
+if ( ! defined( 'ABSPATH' ) ) { exit; }
+
+class CPT_MenuItem {
+    public const SLUG = 'vc_menu_item';
+    public const TAX_CATEGORY = 'vc_menu_category';
+
+    public function init(): void {
+        add_action( 'init', [ $this, 'register_cpt' ] );
+        add_action( 'init', [ $this, 'register_taxonomies' ] );
+        add_action( 'add_meta_boxes', [ $this, 'register_metaboxes' ] );
+        add_action( 'save_post_' . self::SLUG, [ $this, 'save_meta' ] );
+        add_filter( 'manage_' . self::SLUG . '_posts_columns', [ $this, 'admin_columns' ] );
+        add_action( 'manage_' . self::SLUG . '_posts_custom_column', [ $this, 'admin_column_values' ], 10, 2 );
+    }
+
+    public function register_cpt(): void {
+        $labels = [ 'name' => __( 'Itens do Cardápio', 'vemcomer' ), 'singular_name' => __( 'Item do Cardápio', 'vemcomer' ) ];
+        $args = [
+            'labels' => $labels,
+            'public' => true,
+            'show_ui' => true,
+            'show_in_menu' => false,
+            'show_in_rest' => true,
+            'supports' => [ 'title', 'editor', 'thumbnail' ],
+            'has_archive' => false,
+            'rewrite' => [ 'slug' => 'menu-item' ],
+        ];
+        register_post_type( self::SLUG, $args );
+    }
+
+    public function register_taxonomies(): void {
+        $labels = [ 'name' => __( 'Categorias do Cardápio', 'vemcomer' ), 'singular_name' => __( 'Categoria do Cardápio', 'vemcomer' ) ];
+        register_taxonomy( self::TAX_CATEGORY, [ self::SLUG ], [
+            'labels' => $labels,
+            'public' => true,
+            'hierarchical' => true,
+            'show_ui' => true,
+            'show_in_rest' => true,
+        ] );
+    }
+
+    public function register_metaboxes(): void {
+        add_meta_box( 'vc_menu_item_info', __( 'Informações do Item', 'vemcomer' ), [ $this, 'render_metabox' ], self::SLUG, 'normal', 'default' );
+    }
+
+    public function render_metabox( $post ): void {
+        $fields = $this->get_fields( (int) $post->ID );
+        wp_nonce_field( 'vc_menu_item_nonce', 'vc_menu_item_nonce_field' );
+        echo '<table class="form-table">';
+        // Relacionamento com Restaurante
+        echo '<tr><th><label for="vc_restaurant_id">' . esc_html__( 'Restaurante', 'vemcomer' ) . '</label></th><td>';
+        wp_dropdown_pages([
+            'post_type'        => CPT_Restaurant::SLUG,
+            'name'             => 'vc_restaurant_id',
+            'id'               => 'vc_restaurant_id',
+            'show_option_none' => __( '— Selecione —', 'vemcomer' ),
+            'option_none_value'=> '',
+            'selected'         => $fields['restaurant_id'],
+        ]);
+        echo '</td></tr>';
+        // Preço
+        $this->text_row( 'vc_price', __( 'Preço', 'vemcomer' ), $fields['price'] );
+        // Tempo de preparo
+        $this->text_row( 'vc_prep_time', __( 'Tempo de preparo (min)', 'vemcomer' ), $fields['prep_time'] );
+        // Disponibilidade
+        echo '<tr><th>' . esc_html__( 'Disponível', 'vemcomer' ) . '</th><td>';
+        echo '<label><input type="checkbox" name="vc_is_available" value="1" ' . checked( $fields['is_available'], '1', false ) . ' /> ' . esc_html__( 'Ativo', 'vemcomer' ) . '</label>';
+        echo '</td></tr>';
+        echo '</table>';
+    }
+
+    private function text_row( string $name, string $label, string $value ): void {
+        echo '<tr><th><label for="' . esc_attr( $name ) . '">' . esc_html( $label ) . '</label></th>';
+        echo '<td><input type="text" class="regular-text" id="' . esc_attr( $name ) . '" name="' . esc_attr( $name ) . '" value="' . esc_attr( $value ) . '" /></td></tr>';
+    }
+
+    private function get_fields( int $post_id ): array {
+        return [
+            'restaurant_id' => (int) get_post_meta( $post_id, '_vc_restaurant_id', true ),
+            'price'         => (string) get_post_meta( $post_id, '_vc_price', true ),
+            'prep_time'     => (string) get_post_meta( $post_id, '_vc_prep_time', true ),
+            'is_available'  => (string) get_post_meta( $post_id, '_vc_is_available', true ),
+        ];
+    }
+
+    public function save_meta( int $post_id ): void {
+        if ( ! isset( $_POST['vc_menu_item_nonce_field'] ) || ! wp_verify_nonce( $_POST['vc_menu_item_nonce_field'], 'vc_menu_item_nonce' ) ) { return; }
+        if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) { return; }
+        if ( ! current_user_can( 'edit_post', $post_id ) ) { return; }
+        $restaurant_id = isset( $_POST['vc_restaurant_id'] ) ? (int) $_POST['vc_restaurant_id'] : 0;
+        $price         = isset( $_POST['vc_price'] ) ? preg_replace( '/[^0-9.,]/', '', (string) wp_unslash( $_POST['vc_price'] ) ) : '';
+        $prep_time     = isset( $_POST['vc_prep_time'] ) ? preg_replace( '/[^0-9]/', '', (string) wp_unslash( $_POST['vc_prep_time'] ) ) : '';
+        $is_available  = isset( $_POST['vc_is_available'] ) ? '1' : '';
+        update_post_meta( $post_id, '_vc_restaurant_id', $restaurant_id );
+        update_post_meta( $post_id, '_vc_price', $price );
+        update_post_meta( $post_id, '_vc_prep_time', $prep_time );
+        update_post_meta( $post_id, '_vc_is_available', $is_available );
+    }
+
+    public function admin_columns( array $columns ): array {
+        $before = [ 'cb' => $columns['cb'] ?? '', 'title' => $columns['title'] ?? __( 'Título', 'vemcomer' ) ];
+        $extra  = [ 'vc_restaurant' => __( 'Restaurante', 'vemcomer' ), 'vc_price' => __( 'Preço', 'vemcomer' ), 'vc_is_available' => __( 'Disponível', 'vemcomer' ) ];
+        $rest   = $columns; unset( $rest['cb'], $rest['title'] );
+        return array_merge( $before, $extra, $rest );
+    }
+
+    public function admin_column_values( string $column, int $post_id ): void {
+        if ( 'vc_restaurant' === $column ) {
+            $rid = (int) get_post_meta( $post_id, '_vc_restaurant_id', true );
+            echo esc_html( $rid ? get_the_title( $rid ) : '—' );
+            return;
+        }
+        if ( 'vc_price' === $column ) {
+            echo esc_html( (string) get_post_meta( $post_id, '_vc_price', true ) );
+            return;
+        }
+        if ( 'vc_is_available' === $column ) {
+            $v = (string) get_post_meta( $post_id, '_vc_is_available', true );
+            echo esc_html( $v ? __( 'Sim', 'vemcomer' ) : __( 'Não', 'vemcomer' ) );
+        }
+    }
+}

--- a/inc/Model/CPT_Restaurant.php
+++ b/inc/Model/CPT_Restaurant.php
@@ -1,0 +1,128 @@
+<?php
+/**
+ * CPT_Restaurant — Custom Post Type "Restaurant" (Restaurantes)
+ * @package VemComerCore
+ */
+
+namespace VC\Model;
+
+if ( ! defined( 'ABSPATH' ) ) { exit; }
+
+class CPT_Restaurant {
+    public const SLUG = 'vc_restaurant';
+    public const TAX_CUISINE = 'vc_cuisine';
+
+    public function init(): void {
+        add_action( 'init', [ $this, 'register_cpt' ] );
+        add_action( 'init', [ $this, 'register_taxonomies' ] );
+        add_action( 'add_meta_boxes', [ $this, 'register_metaboxes' ] );
+        add_action( 'save_post_' . self::SLUG, [ $this, 'save_meta' ] );
+        add_filter( 'manage_' . self::SLUG . '_posts_columns', [ $this, 'admin_columns' ] );
+        add_action( 'manage_' . self::SLUG . '_posts_custom_column', [ $this, 'admin_column_values' ], 10, 2 );
+    }
+
+    public function register_cpt(): void {
+        $labels = [
+            'name' => __( 'Restaurantes', 'vemcomer' ),
+            'singular_name' => __( 'Restaurante', 'vemcomer' ),
+        ];
+        $args = [
+            'labels' => $labels,
+            'public' => true,
+            'show_ui' => true,
+            'show_in_menu' => false,
+            'show_in_rest' => true,
+            'supports' => [ 'title', 'editor', 'thumbnail' ],
+            'has_archive' => false,
+            'rewrite' => [ 'slug' => 'restaurant' ],
+        ];
+        register_post_type( self::SLUG, $args );
+    }
+
+    public function register_taxonomies(): void {
+        $labels = [ 'name' => __( 'Cozinhas', 'vemcomer' ), 'singular_name' => __( 'Cozinha', 'vemcomer' ) ];
+        register_taxonomy( self::TAX_CUISINE, [ self::SLUG ], [
+            'labels' => $labels,
+            'public' => true,
+            'hierarchical' => true,
+            'show_ui' => true,
+            'show_in_rest' => true,
+        ] );
+    }
+
+    public function register_metaboxes(): void {
+        add_meta_box( 'vc_restaurant_info', __( 'Informações do Restaurante', 'vemcomer' ), [ $this, 'render_metabox' ], self::SLUG, 'normal', 'high' );
+    }
+
+    public function render_metabox( $post ): void {
+        $fields = $this->get_fields( (int) $post->ID );
+        wp_nonce_field( 'vc_restaurant_nonce', 'vc_restaurant_nonce_field' );
+        echo '<table class="form-table">';
+        $this->text_row( 'vc_address', __( 'Endereço', 'vemcomer' ), $fields['address'] );
+        $this->text_row( 'vc_phone', __( 'Telefone', 'vemcomer' ), $fields['phone'] );
+        $this->text_row( 'vc_whatsapp', __( 'WhatsApp', 'vemcomer' ), $fields['whatsapp'] );
+        $this->text_row( 'vc_min_order', __( 'Pedido mínimo', 'vemcomer' ), $fields['min_order'] );
+        $this->text_row( 'vc_delivery_time', __( 'Tempo de entrega (min)', 'vemcomer' ), $fields['delivery_time'] );
+        $this->text_row( 'vc_opening_hours', __( 'Horário de funcionamento', 'vemcomer' ), $fields['opening_hours'] );
+        $this->checkbox_row( 'vc_is_open', __( 'Aberto agora', 'vemcomer' ), $fields['is_open'] );
+        echo '</table>';
+    }
+
+    private function text_row( string $name, string $label, string $value ): void {
+        echo '<tr><th><label for="' . esc_attr( $name ) . '">' . esc_html( $label ) . '</label></th>';
+        echo '<td><input type="text" class="regular-text" id="' . esc_attr( $name ) . '" name="' . esc_attr( $name ) . '" value="' . esc_attr( $value ) . '" /></td></tr>';
+    }
+
+    private function checkbox_row( string $name, string $label, string $checked ): void {
+        $check = $checked ? 'checked' : '';
+        echo '<tr><th>' . esc_html( $label ) . '</th>';
+        echo '<td><label><input type="checkbox" id="' . esc_attr( $name ) . '" name="' . esc_attr( $name ) . '" value="1" ' . $check . ' /> ' . esc_html__( 'Ativo', 'vemcomer' ) . '</label></td></tr>';
+    }
+
+    private function get_fields( int $post_id ): array {
+        return [
+            'address'       => (string) get_post_meta( $post_id, '_vc_address', true ),
+            'phone'         => (string) get_post_meta( $post_id, '_vc_phone', true ),
+            'whatsapp'      => (string) get_post_meta( $post_id, '_vc_whatsapp', true ),
+            'min_order'     => (string) get_post_meta( $post_id, '_vc_min_order', true ),
+            'delivery_time' => (string) get_post_meta( $post_id, '_vc_delivery_time', true ),
+            'opening_hours' => (string) get_post_meta( $post_id, '_vc_opening_hours', true ),
+            'is_open'       => (string) get_post_meta( $post_id, '_vc_is_open', true ),
+        ];
+    }
+
+    public function save_meta( int $post_id ): void {
+        if ( ! isset( $_POST['vc_restaurant_nonce_field'] ) || ! wp_verify_nonce( $_POST['vc_restaurant_nonce_field'], 'vc_restaurant_nonce' ) ) { return; }
+        if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) { return; }
+        if ( ! current_user_can( 'edit_post', $post_id ) ) { return; }
+        $address       = isset( $_POST['vc_address'] ) ? sanitize_text_field( wp_unslash( $_POST['vc_address'] ) ) : '';
+        $phone         = isset( $_POST['vc_phone'] ) ? sanitize_text_field( wp_unslash( $_POST['vc_phone'] ) ) : '';
+        $whatsapp      = isset( $_POST['vc_whatsapp'] ) ? sanitize_text_field( wp_unslash( $_POST['vc_whatsapp'] ) ) : '';
+        $min_order     = isset( $_POST['vc_min_order'] ) ? preg_replace( '/[^0-9.,]/', '', (string) wp_unslash( $_POST['vc_min_order'] ) ) : '';
+        $delivery_time = isset( $_POST['vc_delivery_time'] ) ? preg_replace( '/[^0-9]/', '', (string) wp_unslash( $_POST['vc_delivery_time'] ) ) : '';
+        $opening_hours = isset( $_POST['vc_opening_hours'] ) ? sanitize_text_field( wp_unslash( $_POST['vc_opening_hours'] ) ) : '';
+        $is_open       = isset( $_POST['vc_is_open'] ) ? '1' : '';
+        update_post_meta( $post_id, '_vc_address', $address );
+        update_post_meta( $post_id, '_vc_phone', $phone );
+        update_post_meta( $post_id, '_vc_whatsapp', $whatsapp );
+        update_post_meta( $post_id, '_vc_min_order', $min_order );
+        update_post_meta( $post_id, '_vc_delivery_time', $delivery_time );
+        update_post_meta( $post_id, '_vc_opening_hours', $opening_hours );
+        update_post_meta( $post_id, '_vc_is_open', $is_open );
+    }
+
+    public function admin_columns( array $columns ): array {
+        $before = [ 'cb' => $columns['cb'] ?? '', 'title' => $columns['title'] ?? __( 'Título', 'vemcomer' ) ];
+        $extra  = [ 'vc_address' => __( 'Endereço', 'vemcomer' ), 'vc_phone' => __( 'Telefone', 'vemcomer' ), 'vc_min_order' => __( 'Pedido mínimo', 'vemcomer' ), 'vc_is_open' => __( 'Aberto', 'vemcomer' ) ];
+        $rest   = $columns; unset( $rest['cb'], $rest['title'] );
+        return array_merge( $before, $extra, $rest );
+    }
+
+    public function admin_column_values( string $column, int $post_id ): void {
+        $map = [ 'vc_address' => '_vc_address', 'vc_phone' => '_vc_phone', 'vc_min_order' => '_vc_min_order', 'vc_is_open' => '_vc_is_open' ];
+        if ( isset( $map[ $column ] ) ) {
+            $value = get_post_meta( $post_id, $map[ $column ], true );
+            echo esc_html( $column === 'vc_is_open' ? ( $value ? __( 'Sim', 'vemcomer' ) : __( 'Não', 'vemcomer' ) ) : (string) $value );
+        }
+    }
+}

--- a/inc/REST/Restaurant_Controller.php
+++ b/inc/REST/Restaurant_Controller.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * Restaurant_Controller — REST endpoints públicos para restaurantes e itens
+ * @package VemComerCore
+ */
+
+namespace VC\REST;
+
+use VC\Model\CPT_Restaurant;
+use VC\Model\CPT_MenuItem;
+use WP_Query;
+use WP_REST_Request;
+use WP_Error;
+
+if ( ! defined( 'ABSPATH' ) ) { exit; }
+
+class Restaurant_Controller {
+    public function init(): void {
+        add_action( 'rest_api_init', [ $this, 'routes' ] );
+    }
+
+    public function routes(): void {
+        register_rest_route( 'vemcomer/v1', '/restaurants', [
+            'methods'             => 'GET',
+            'callback'            => [ $this, 'get_restaurants' ],
+            'permission_callback' => '__return_true',
+        ] );
+
+        register_rest_route( 'vemcomer/v1', '/restaurants/(?P<id>\\d+)/menu-items', [
+            'methods'             => 'GET',
+            'callback'            => [ $this, 'get_menu_items' ],
+            'permission_callback' => '__return_true',
+            'args'                => [ 'id' => [ 'validate_callback' => 'is_numeric' ] ],
+        ] );
+    }
+
+    public function get_restaurants( WP_REST_Request $request ) {
+        $q = new WP_Query([
+            'post_type'      => CPT_Restaurant::SLUG,
+            'posts_per_page' => 50,
+            'no_found_rows'  => true,
+            'post_status'    => 'publish',
+        ]);
+        $items = [];
+        foreach ( $q->posts as $p ) {
+            $items[] = [
+                'id'            => $p->ID,
+                'title'         => get_the_title( $p ),
+                'address'       => get_post_meta( $p->ID, '_vc_address', true ),
+                'phone'         => get_post_meta( $p->ID, '_vc_phone', true ),
+                'whatsapp'      => get_post_meta( $p->ID, '_vc_whatsapp', true ),
+                'min_order'     => get_post_meta( $p->ID, '_vc_min_order', true ),
+                'delivery_time' => get_post_meta( $p->ID, '_vc_delivery_time', true ),
+                'opening_hours' => get_post_meta( $p->ID, '_vc_opening_hours', true ),
+                'is_open'       => (bool) get_post_meta( $p->ID, '_vc_is_open', true ),
+                'cuisines'      => wp_get_post_terms( $p->ID, CPT_Restaurant::TAX_CUISINE, [ 'fields' => 'names' ] ),
+            ];
+        }
+        return rest_ensure_response( $items );
+    }
+
+    public function get_menu_items( WP_REST_Request $request ) {
+        $rid = (int) $request->get_param( 'id' );
+        if ( $rid <= 0 ) {
+            return new WP_Error( 'vc_invalid_restaurant', __( 'Restaurante inválido.', 'vemcomer' ), [ 'status' => 400 ] );
+        }
+        $q = new WP_Query([
+            'post_type'      => CPT_MenuItem::SLUG,
+            'posts_per_page' => 100,
+            'no_found_rows'  => true,
+            'post_status'    => 'publish',
+            'meta_query'     => [ [ 'key' => '_vc_restaurant_id', 'value' => $rid, 'compare' => '=' ] ],
+        ]);
+        $items = [];
+        foreach ( $q->posts as $p ) {
+            $items[] = [
+                'id'          => $p->ID,
+                'title'       => get_the_title( $p ),
+                'description' => wp_strip_all_tags( get_post_field( 'post_content', $p ) ),
+                'price'       => get_post_meta( $p->ID, '_vc_price', true ),
+                'prep_time'   => get_post_meta( $p->ID, '_vc_prep_time', true ),
+                'available'   => (bool) get_post_meta( $p->ID, '_vc_is_available', true ),
+                'categories'  => wp_get_post_terms( $p->ID, CPT_MenuItem::TAX_CATEGORY, [ 'fields' => 'names' ] ),
+            ];
+        }
+        return rest_ensure_response( $items );
+    }
+}

--- a/vemcomer-core.php
+++ b/vemcomer-core.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: VemComer Core
  * Description: Core do marketplace VemComer — CPTs, Admin e REST base.
- * Version: 0.1.0
+ * Version: 0.2.0
  * Requires at least: 6.0
  * Requires PHP: 8.0
  * Author: VemComer
@@ -11,38 +11,48 @@
 
 if ( ! defined( 'ABSPATH' ) ) { exit; }
 
-// Constantes básicas
-define( 'VEMCOMER_CORE_VERSION', '0.1.0' );
+define( 'VEMCOMER_CORE_VERSION', '0.2.0' );
 define( 'VEMCOMER_CORE_FILE', __FILE__ );
 define( 'VEMCOMER_CORE_DIR', plugin_dir_path( __FILE__ ) );
 define( 'VEMCOMER_CORE_URL', plugin_dir_url( __FILE__ ) );
 
-// Autoload simples das classes do inc/
+// Autoload legado: classes no formato VC_*
 spl_autoload_register( function ( $class ) {
     if ( str_starts_with( $class, 'VC_' ) ) {
         $path = VEMCOMER_CORE_DIR . 'inc/' . 'class-' . strtolower( str_replace( '_', '-', $class ) ) . '.php';
-        if ( file_exists( $path ) ) {
-            require_once $path;
-        }
+        if ( file_exists( $path ) ) { require_once $path; }
+    }
+} );
+
+// Autoload PSR-4 simples: namespace VC\* mapeado para inc/
+spl_autoload_register( function ( $class ) {
+    if ( str_starts_with( $class, 'VC\\' ) ) {
+        $relative = str_replace( 'VC\\', '', $class );
+        $relative = str_replace( '\\', '/', $relative );
+        $path = VEMCOMER_CORE_DIR . 'inc/' . $relative . '.php';
+        if ( file_exists( $path ) ) { require_once $path; }
     }
 } );
 
 // Helpers comuns
 require_once VEMCOMER_CORE_DIR . 'inc/helpers-sanitize.php';
 
-// Bootstrap
 add_action( 'plugins_loaded', function () {
-    // Loader central (ganchos, assets, etc.)
-    $loader = new VC_Loader();
-    $loader->init();
+    // Loader central (assets)
+    if ( class_exists( 'VC_Loader' ) ) {
+        $loader = new \VC_Loader();
+        $loader->init();
+    }
 
-    // CPTs
-    ( new VC_CPT_Produto() )->init();
-    ( new VC_CPT_Pedido() )->init();
+    // Legacy CPTs (pacote 1)
+    if ( class_exists( 'VC_CPT_Produto' ) ) { ( new \VC_CPT_Produto() )->init(); }
+    if ( class_exists( 'VC_CPT_Pedido' ) )  { ( new \VC_CPT_Pedido() )->init(); }
+    if ( class_exists( 'VC_Admin_Menu' ) )  { ( new \VC_Admin_Menu() )->init(); }
+    if ( class_exists( 'VC_REST' ) )        { ( new \VC_REST() )->init(); }
 
-    // Admin
-    ( new VC_Admin_Menu() )->init();
-
-    // REST
-    ( new VC_REST() )->init();
+    // Novos módulos (pacote 2)
+    if ( class_exists( '\\VC\\Model\\CPT_Restaurant' ) )      { ( new \VC\Model\CPT_Restaurant() )->init(); }
+    if ( class_exists( '\\VC\\Model\\CPT_MenuItem' ) )        { ( new \VC\Model\CPT_MenuItem() )->init(); }
+    if ( class_exists( '\\VC\\Admin\\Menu_Restaurant' ) )     { ( new \VC\Admin\Menu_Restaurant() )->init(); }
+    if ( class_exists( '\\VC\\REST\\Restaurant_Controller' ) ) { ( new \VC\REST\Restaurant_Controller() )->init(); }
 } );


### PR DESCRIPTION
## Summary
- add Restaurant and Menu Item CPT classes with meta handling and admin columns
- expose public REST routes and admin menu links for the new resources
- update the plugin bootstrap to support PSR-4 autoloading and initialize new modules

## Testing
- php -l vemcomer-core.php
- php -l inc/Model/CPT_Restaurant.php
- php -l inc/Model/CPT_MenuItem.php
- php -l inc/REST/Restaurant_Controller.php
- php -l inc/Admin/Menu_Restaurant.php

------
https://chatgpt.com/codex/tasks/task_b_68df48eb5cac832bac39f8278a1c787f