### PR TITLE
Add settings API, order statuses, webhook, and CLI seed

### DIFF
--- a/inc/Admin/Settings.php
+++ b/inc/Admin/Settings.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * Settings — Página de Configurações (Settings API)
+ * @package VemComerCore
+ */
+
+namespace VC\Admin;
+
+if ( ! defined( 'ABSPATH' ) ) { exit; }
+
+class Settings {
+    public const OPTION_GROUP = 'vemcomer_settings_group';
+    public const OPTION_NAME  = 'vemcomer_settings';
+    public const PAGE_SLUG    = 'vemcomer-settings';
+
+    public function init(): void {
+        add_action( 'admin_init', [ $this, 'register_settings' ] );
+        add_action( 'admin_menu', [ $this, 'ensure_menu' ], 20 );
+    }
+
+    /** Garante que a página de Configurações exista como submenu (caso não tenha o pacote 1) */
+    public function ensure_menu(): void {
+        add_submenu_page( 'vemcomer-root', __( 'Configurações', 'vemcomer' ), __( 'Configurações', 'vemcomer' ), 'manage_options', self::PAGE_SLUG, [ $this, 'render_page' ] );
+    }
+
+    public function register_settings(): void {
+        register_setting( self::OPTION_GROUP, self::OPTION_NAME, [ $this, 'sanitize' ] );
+
+        add_settings_section( 'vc_general', __( 'Geral', 'vemcomer' ), function () {
+            echo '<p>' . esc_html__( 'Defina chaves e integrações.', 'vemcomer' ) . '</p>';
+        }, self::PAGE_SLUG );
+
+        add_settings_field( 'payment_provider', __( 'Gateway de Pagamento', 'vemcomer' ), [ $this, 'field_payment_provider' ], self::PAGE_SLUG, 'vc_general' );
+        add_settings_field( 'payment_secret', __( 'Segredo do Webhook (HMAC)', 'vemcomer' ), [ $this, 'field_payment_secret' ], self::PAGE_SLUG, 'vc_general' );
+        add_settings_field( 'delivery_provider', __( 'Serviço de Entrega', 'vemcomer' ), [ $this, 'field_delivery_provider' ], self::PAGE_SLUG, 'vc_general' );
+    }
+
+    public function sanitize( $input ): array {
+        $out = $this->get();
+        $out['payment_provider']  = isset( $input['payment_provider'] ) ? sanitize_text_field( wp_unslash( $input['payment_provider'] ) ) : '';
+        $out['payment_secret']    = isset( $input['payment_secret'] ) ? sanitize_text_field( wp_unslash( $input['payment_secret'] ) ) : '';
+        $out['delivery_provider'] = isset( $input['delivery_provider'] ) ? sanitize_text_field( wp_unslash( $input['delivery_provider'] ) ) : '';
+        return $out;
+    }
+
+    public function get(): array {
+        $defaults = [
+            'payment_provider'  => '',
+            'payment_secret'    => '',
+            'delivery_provider' => '',
+        ];
+        return wp_parse_args( (array) get_option( self::OPTION_NAME, [] ), $defaults );
+    }
+
+    public function render_page(): void {
+        wp_enqueue_style( 'vemcomer-admin' );
+        echo '<div class="wrap">';
+        echo '<h1>' . esc_html__( 'Configurações do VemComer', 'vemcomer' ) . '</h1>';
+        echo '<form method="post" action="options.php">';
+        settings_fields( self::OPTION_GROUP );
+        do_settings_sections( self::PAGE_SLUG );
+        submit_button();
+        echo '</form></div>';
+    }
+
+    private function text( string $name, string $value, string $type = 'text', string $placeholder = '' ): void {
+        echo '<input type="' . esc_attr( $type ) . '" class="regular-text" name="' . esc_attr( self::OPTION_NAME . "[$name]" ) . '" value="' . esc_attr( $value ) . '" placeholder="' . esc_attr( $placeholder ) . '" />';
+    }
+
+    public function field_payment_provider(): void {
+        $o = $this->get();
+        $this->text( 'payment_provider', (string) $o['payment_provider'], 'text', 'ex.: stripe, pagarme' );
+    }
+    public function field_payment_secret(): void {
+        $o = $this->get();
+        $this->text( 'payment_secret', (string) $o['payment_secret'], 'password', 'segredo usado no HMAC' );
+    }
+    public function field_delivery_provider(): void {
+        $o = $this->get();
+        $this->text( 'delivery_provider', (string) $o['delivery_provider'], 'text', 'ex.: loggi, lalamove' );
+    }
+}

--- a/inc/CLI/Seed.php
+++ b/inc/CLI/Seed.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Seed — Comandos WP-CLI para popular dados de demo
+ * @package VemComerCore
+ */
+
+namespace VC\CLI;
+
+use VC\Model\CPT_Restaurant;
+use VC\Model\CPT_MenuItem;
+
+if ( ! defined( 'ABSPATH' ) ) { exit; }
+
+class Seed {
+    public function init(): void {
+        if ( defined( 'WP_CLI' ) && WP_CLI ) {
+            \WP_CLI::add_command( 'vc seed', [ $this, 'cmd_seed' ] );
+        }
+    }
+
+    /**
+     * wp vc seed
+     */
+    public function cmd_seed( $args, $assoc_args ): void {
+        $rid = wp_insert_post([
+            'post_type'   => CPT_Restaurant::SLUG,
+            'post_title'  => 'VemComer Demo Restaurant',
+            'post_status' => 'publish',
+        ]);
+        update_post_meta( $rid, '_vc_address', 'Rua Exemplo, 123' );
+        update_post_meta( $rid, '_vc_phone', '(11) 99999-9999' );
+        update_post_meta( $rid, '_vc_min_order', '29,90' );
+        update_post_meta( $rid, '_vc_is_open', '1' );
+
+        for ( $i = 1; $i <= 5; $i++ ) {
+            $mid = wp_insert_post([
+                'post_type'   => CPT_MenuItem::SLUG,
+                'post_title'  => 'Item ' . $i,
+                'post_content'=> 'Descrição do item ' . $i,
+                'post_status' => 'publish',
+            ]);
+            update_post_meta( $mid, '_vc_restaurant_id', $rid );
+            update_post_meta( $mid, '_vc_price', (string) (10 * $i) . ',00' );
+            update_post_meta( $mid, '_vc_prep_time', (string) (5 * $i) );
+            update_post_meta( $mid, '_vc_is_available', '1' );
+        }
+
+        if ( class_exists( 'WP_CLI' ) ) { \WP_CLI::success( 'Seed concluído: restaurante + 5 itens.' ); }
+    }
+}

--- a/inc/Order/Statuses.php
+++ b/inc/Order/Statuses.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * Statuses — Post Statuses e metabox de status para Pedidos
+ * @package VemComerCore
+ */
+
+namespace VC\Order;
+
+use VC_CPT_Pedido;
+
+if ( ! defined( 'ABSPATH' ) ) { exit; }
+
+class Statuses {
+    public const STATUSES = [
+        'vc-pending'    => 'Pendente',
+        'vc-paid'       => 'Pago',
+        'vc-preparing'  => 'Preparando',
+        'vc-delivering' => 'Em entrega',
+        'vc-completed'  => 'Concluído',
+        'vc-cancelled'  => 'Cancelado',
+    ];
+
+    public function init(): void {
+        add_action( 'init', [ $this, 'register_statuses' ] );
+        add_action( 'add_meta_boxes', [ $this, 'metabox' ] );
+        add_action( 'save_post_' . VC_CPT_Pedido::SLUG, [ $this, 'save' ] );
+        add_filter( 'display_post_states', [ $this, 'list_states' ], 10, 2 );
+    }
+
+    public function register_statuses(): void {
+        foreach ( self::STATUSES as $key => $label ) {
+            register_post_status( $key, [
+                'label'                     => $label,
+                'public'                    => true,
+                'internal'                  => false,
+                'exclude_from_search'       => false,
+                'show_in_admin_all_list'    => true,
+                'show_in_admin_status_list' => true,
+                'label_count'               => _n_noop( "$label <span class=\"count\">(%s)</span>", "$label <span class=\"count\">(%s)</span>", 'vemcomer' ),
+            ] );
+        }
+    }
+
+    public function metabox(): void {
+        add_meta_box( 'vc_order_status', __( 'Status do Pedido', 'vemcomer' ), [ $this, 'render' ], VC_CPT_Pedido::SLUG, 'side', 'high' );
+    }
+
+    public function render( $post ): void {
+        $current = get_post_status( $post );
+        wp_nonce_field( 'vc_order_status_nonce', 'vc_order_status_nonce_field' );
+        echo '<p><label for="vc_order_status_sel">' . esc_html__( 'Selecionar status', 'vemcomer' ) . '</label></p>';
+        echo '<select id="vc_order_status_sel" name="vc_order_status_sel" class="widefat">';
+        foreach ( self::STATUSES as $key => $label ) {
+            echo '<option value="' . esc_attr( $key ) . '" ' . selected( $current, $key, false ) . '>' . esc_html( $label ) . '</option>';
+        }
+        echo '</select>';
+    }
+
+    public function save( int $post_id ): void {
+        if ( ! isset( $_POST['vc_order_status_nonce_field'] ) || ! wp_verify_nonce( $_POST['vc_order_status_nonce_field'], 'vc_order_status_nonce' ) ) { return; }
+        if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) { return; }
+        if ( ! current_user_can( 'edit_post', $post_id ) ) { return; }
+        if ( isset( $_POST['vc_order_status_sel'] ) ) {
+            $new = sanitize_text_field( wp_unslash( $_POST['vc_order_status_sel'] ) );
+            if ( isset( self::STATUSES[ $new ] ) ) {
+                // muda o post_status sem alterar a data
+                global $wpdb;
+                $wpdb->update( $wpdb->posts, [ 'post_status' => $new ], [ 'ID' => $post_id ] );
+                clean_post_cache( $post_id );
+            }
+        }
+    }
+
+    public function list_states( array $states, $post ): array {
+        if ( VC_CPT_Pedido::SLUG !== $post->post_type ) { return $states; }
+        $ps = get_post_status( $post );
+        if ( isset( self::STATUSES[ $ps ] ) ) {
+            $states[ $ps ] = self::STATUSES[ $ps ];
+        }
+        return $states;
+    }
+}

--- a/inc/REST/Webhooks_Controller.php
+++ b/inc/REST/Webhooks_Controller.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * Webhooks_Controller — Endpoints para webhooks (pagamento)
+ * @package VemComerCore
+ */
+
+namespace VC\REST;
+
+use VC\Admin\Settings;
+use VC_CPT_Pedido;
+use WP_REST_Request;
+use WP_Error;
+
+if ( ! defined( 'ABSPATH' ) ) { exit; }
+
+class Webhooks_Controller {
+    public function init(): void {
+        add_action( 'rest_api_init', [ $this, 'routes' ] );
+    }
+
+    public function routes(): void {
+        register_rest_route( 'vemcomer/v1', '/webhook/payment', [
+            'methods'             => 'POST',
+            'callback'            => [ $this, 'handle_payment' ],
+            'permission_callback' => '__return_true', // verificação é por assinatura
+        ] );
+    }
+
+    /**
+     * Espera JSON: { "order_id": int, "status": "paid|failed|refunded", "amount": "99,90", "ts": 1690000000 }
+     * Header: X-VemComer-Signature: sha256=HMAC_HEX( body, payment_secret )
+     */
+    public function handle_payment( WP_REST_Request $request ) {
+        $raw = $request->get_body();
+        $settings = ( new Settings() )->get();
+        $secret = (string) ( $settings['payment_secret'] ?? '' );
+        if ( empty( $secret ) ) {
+            return new WP_Error( 'vc_no_secret', __( 'Segredo não configurado.', 'vemcomer' ), [ 'status' => 500 ] );
+        }
+
+        $sig = $request->get_header( 'X-VemComer-Signature' );
+        if ( ! $this->verify_signature( $raw, $secret, (string) $sig ) ) {
+            return new WP_Error( 'vc_bad_signature', __( 'Assinatura inválida.', 'vemcomer' ), [ 'status' => 401 ] );
+        }
+
+        $data = json_decode( $raw, true );
+        if ( ! is_array( $data ) || empty( $data['order_id'] ) ) {
+            return new WP_Error( 'vc_bad_payload', __( 'Payload inválido.', 'vemcomer' ), [ 'status' => 400 ] );
+        }
+
+        $order_id = (int) $data['order_id'];
+        $status   = (string) ( $data['status'] ?? '' );
+
+        if ( 'paid' === $status ) {
+            // Marca como pago
+            $this->set_status( $order_id, 'vc-paid' );
+        } elseif ( 'refunded' === $status ) {
+            $this->set_status( $order_id, 'vc-cancelled' );
+        }
+
+        do_action( 'vemcomer_webhook_payment_processed', $order_id, $data );
+
+        return rest_ensure_response( [ 'ok' => true ] );
+    }
+
+    private function verify_signature( string $raw, string $secret, string $header ): bool {
+        if ( empty( $header ) ) { return false; }
+        // Suporta formato "sha256=HEX"
+        $parts = explode( '=', $header );
+        $provided = end( $parts );
+        $calc = hash_hmac( 'sha256', $raw, $secret );
+        return hash_equals( $calc, $provided );
+    }
+
+    private function set_status( int $order_id, string $status ): void {
+        global $wpdb;
+        $wpdb->update( $wpdb->posts, [ 'post_status' => $status ], [ 'ID' => $order_id ] );
+        clean_post_cache( $order_id );
+    }
+}

--- a/vemcomer-core.php
+++ b/vemcomer-core.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: VemComer Core
  * Description: Core do marketplace VemComer — CPTs, Admin e REST base.
- * Version: 0.2.0
+ * Version: 0.3.0
  * Requires at least: 6.0
  * Requires PHP: 8.0
  * Author: VemComer
@@ -11,12 +11,15 @@
 
 if ( ! defined( 'ABSPATH' ) ) { exit; }
 
-define( 'VEMCOMER_CORE_VERSION', '0.2.0' );
+define( 'VEMCOMER_CORE_VERSION', '0.3.0' );
+
 define( 'VEMCOMER_CORE_FILE', __FILE__ );
+
 define( 'VEMCOMER_CORE_DIR', plugin_dir_path( __FILE__ ) );
+
 define( 'VEMCOMER_CORE_URL', plugin_dir_url( __FILE__ ) );
 
-// Autoload legado: classes no formato VC_*
+// Autoload legado VC_*
 spl_autoload_register( function ( $class ) {
     if ( str_starts_with( $class, 'VC_' ) ) {
         $path = VEMCOMER_CORE_DIR . 'inc/' . 'class-' . strtolower( str_replace( '_', '-', $class ) ) . '.php';
@@ -24,7 +27,7 @@ spl_autoload_register( function ( $class ) {
     }
 } );
 
-// Autoload PSR-4 simples: namespace VC\* mapeado para inc/
+// Autoload PSR-4 (namespace VC\*)
 spl_autoload_register( function ( $class ) {
     if ( str_starts_with( $class, 'VC\\' ) ) {
         $relative = str_replace( 'VC\\', '', $class );
@@ -34,25 +37,27 @@ spl_autoload_register( function ( $class ) {
     }
 } );
 
-// Helpers comuns
 require_once VEMCOMER_CORE_DIR . 'inc/helpers-sanitize.php';
 
 add_action( 'plugins_loaded', function () {
-    // Loader central (assets)
-    if ( class_exists( 'VC_Loader' ) ) {
-        $loader = new \VC_Loader();
-        $loader->init();
-    }
+    // Loader central
+    if ( class_exists( 'VC_Loader' ) ) { ( new \VC_Loader() )->init(); }
 
-    // Legacy CPTs (pacote 1)
+    // Pacote 1
     if ( class_exists( 'VC_CPT_Produto' ) ) { ( new \VC_CPT_Produto() )->init(); }
     if ( class_exists( 'VC_CPT_Pedido' ) )  { ( new \VC_CPT_Pedido() )->init(); }
     if ( class_exists( 'VC_Admin_Menu' ) )  { ( new \VC_Admin_Menu() )->init(); }
     if ( class_exists( 'VC_REST' ) )        { ( new \VC_REST() )->init(); }
 
-    // Novos módulos (pacote 2)
+    // Pacote 2
     if ( class_exists( '\\VC\\Model\\CPT_Restaurant' ) )      { ( new \VC\Model\CPT_Restaurant() )->init(); }
     if ( class_exists( '\\VC\\Model\\CPT_MenuItem' ) )        { ( new \VC\Model\CPT_MenuItem() )->init(); }
     if ( class_exists( '\\VC\\Admin\\Menu_Restaurant' ) )     { ( new \VC\Admin\Menu_Restaurant() )->init(); }
     if ( class_exists( '\\VC\\REST\\Restaurant_Controller' ) ) { ( new \VC\REST\Restaurant_Controller() )->init(); }
+
+    // Pacote 3
+    if ( class_exists( '\\VC\\Admin\\Settings' ) )            { ( new \VC\Admin\Settings() )->init(); }
+    if ( class_exists( '\\VC\\Order\\Statuses' ) )            { ( new \VC\Order\Statuses() )->init(); }
+    if ( class_exists( '\\VC\\REST\\Webhooks_Controller' ) )  { ( new \VC\REST\Webhooks_Controller() )->init(); }
+    if ( class_exists( '\\VC\\CLI\\Seed' ) )                  { ( new \VC\CLI\Seed() )->init(); }
 } );


### PR DESCRIPTION
## Summary
- add admin settings page to manage integration keys via Settings API
- register order post statuses with a management metabox and REST webhook handler
- add payment webhook signature verification and WP-CLI seed command plus bootstrap updates

## Testing
- php -l inc/Admin/Settings.php
- php -l inc/Order/Statuses.php
- php -l inc/REST/Webhooks_Controller.php
- php -l inc/CLI/Seed.php
- php -l vemcomer-core.php

------
https://chatgpt.com/codex/tasks/task_b_68df4a9f0444832b895396d01ead80c8