### PR TITLE
Add WooCommerce integration and automator hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,67 @@
-# vemcomer-core
-Plugin do marketplace VemComer (WordPress)
+# VemComer Core
+
+Core de marketplace para WordPress com:
+- CPTs: **Produtos**, **Pedidos**, **Restaurantes**, **Itens do Cardápio**.
+- Admin Menu, REST API, Status de Pedido, Webhooks e Seed via WP‑CLI.
+- Integrações: **WooCommerce** (sincroniza pedidos/status) e **Automator** (hooks customizados).
+
+## Instalação e Ativação
+1. Copie o plugin para `wp-content/plugins/vemcomer-core/`.
+2. Ative **VemComer Core** no painel do WordPress.
+3. (Opcional) Configure **VemComer ▸ Configurações** → Segredo do Webhook e integrações.
+
+## Seed (dados de demonstração)
+Cria 1 restaurante e 5 itens de cardápio:
+```bash
+wp vc seed
+```
+
+## Endpoints REST
+
+### Restaurantes
+
+* **GET** `/wp-json/vemcomer/v1/restaurants`
+* **GET** `/wp-json/vemcomer/v1/restaurants/{id}/menu-items`
+
+### Pedidos
+
+* **POST** `/wp-json/vemcomer/v1/pedidos`
+
+  * Body: `{ "itens": [ {"produto_id": 123, "qtd": 2} ], "total": "49,90" }`
+
+### Webhook de Pagamento (entrada)
+
+* **POST** `/wp-json/vemcomer/v1/webhook/payment`
+* Header: `X-VemComer-Signature: sha256=<hmac_hex_do_corpo>`
+* Body: `{ "order_id": 10, "status": "paid|refunded|failed", "amount": "99,90", "ts": 1690000000 }`
+
+## Status de Pedido
+
+Os pedidos (`vc_pedido`) podem ter:
+`vc-pending`, `vc-paid`, `vc-preparing`, `vc-delivering`, `vc-completed`, `vc-cancelled`.
+Você pode mudar pelo metabox lateral do pedido ou via integrações.
+
+## Integrações
+
+### WooCommerce (opcional)
+
+* Sincroniza **status**: `processing → vc-paid`, `completed → vc-completed`, `cancelled → vc-cancelled`, `on-hold → vc-pending`.
+* Se um pedido WooCommerce não tiver vínculo, o plugin cria automaticamente um `vc_pedido` espelhando **itens** e **total**, e vincula via meta `_vc_wc_order_id` (WC) e `_vc_linked_wc_order` (VC).
+
+### Automator (Uncanny/AutomatorWP)
+
+O plugin expõe **actions** que podem ser usadas como **gatilhos de hook personalizado**:
+
+* `vemcomer/order_status_changed`, args: `(int $vc_order_id, string $new_status, string $old_status)`
+* `vemcomer/order_paid`, args: `(int $vc_order_id)`
+* `vemcomer/webhook_payment_processed`, args: `(int $vc_order_id, array $payload)`
+* `vemcomer/restaurant_created`, args: `(int $restaurant_id)`
+
+Use esses nomes nos “Custom Action Hook” dos automators para disparar receitas.
+
+## Desenvolvimento
+
+* PHP ≥ 8.0, WP ≥ 6.0.
+* Autoload interno + PSR‑4 simples (namespace `VC\*` mapeado para `inc/`).
+* Sanitização e escapes seguindo o Handbook do WordPress.
+

--- a/docs/checklist-v0.6.md
+++ b/docs/checklist-v0.6.md
@@ -1,0 +1,165 @@
+# Vemcomer Core — Checklist de Implementação (v0.6+)
+
+> Diretrizes fixas: ✅ Pagamento 100% offline · ✅ Single-seller · ✅ Geo/horários respeitados
+
+## 🔖 Marcos
+- [ ] **v0.6.0 – Base & modularização**
+- [ ] **v0.6.1 – Filtros, UX e cache GEO**
+- [ ] **v0.6.2 – Regras de negócio & REST**
+- [ ] **v0.6.3 – Webhooks/Automations & Relatórios**
+- [ ] **v0.6.4 – A11y, SEO & Performance**
+
+---
+
+## 0) Higiene e fundação
+- [ ] Blindar `define()` de constantes (URL/PATH/VERSION) com `if (!defined(...))`
+- [ ] `require_once` de módulos fora de `if` de versão
+- [ ] Um único plugin ativo (evitar *Cannot redeclare*/duplicidades)
+- [ ] Ativar `WP_DEBUG` + `WP_DEBUG_LOG` (sem display) e validar `wp-content/debug.log`
+- [ ] Bump de versão ao alterar JS/CSS (`Version:` + `VEMCOMER_CORE_VERSION`)
+
+---
+
+## 1) Modularização (/inc) — v0.6.0
+- [ ] **/inc/bootstrap.php** — registrar assets (não enfileirar global)
+- [ ] **/inc/filters.php** — filtros públicos:
+  - [ ] `vemcomer_kds_poll`
+  - [ ] `vemcomer_tiles_url`
+  - [ ] `vemcomer_default_radius`
+  - [ ] `vemcomer_checkout_labels`
+  - [ ] `vemcomer_order_webhook_payload`
+- [ ] **/inc/geo.php** — `vc_geo_cache_get/set`, `vc_haversine_km` (com `function_exists`)
+- [ ] **/inc/restaurants.php** — helpers: aceitar pedidos, horários, raio
+- [ ] **/inc/checkout.php** — campos, validações, fees, single-seller
+- [ ] **/inc/kds.php** — `wp_localize_script` (VC_KDS: rest, nonce, rid, poll)
+- [ ] **/inc/rest.php** — rotas REST (orders list + mutate status)
+- [ ] **/inc/shortcodes.php** — [vc_explore], [vc_restaurant_menu], [vc_kds], etc.
+- [ ] **/inc/settings.php** — página de opções no Admin
+- [ ] Incluir todos os `require_once` no arquivo principal
+- [ ] QA de regressão: explorar, restaurante, checkout GEO, KDS, favoritos, histórico
+
+---
+
+## 2) Regras de negócio (WooCommerce) — v0.6.2
+### 2.1 Single-seller
+- [ ] Validação `woocommerce_add_to_cart_validation` impede misturar restaurantes
+- [ ] Mensagem clara ao usuário (notice de erro)
+- [ ] Testes: carrinho com itens A → tentar adicionar B = bloqueado
+
+### 2.2 Fechado = não comprável
+- [ ] `woocommerce_is_purchasable` retorna `false` se loja pausada ou fora do horário
+- [ ] UI: badge “Fechado” + CTA desabilitado/aviso
+- [ ] Testes: simular horário fechado → impedir add-to-cart
+
+### 2.3 Frete (base + km + grátis > X)
+- [ ] Calcular distância com `vc_haversine_km` (restaurante ↔ cliente)
+- [ ] `woocommerce_cart_calculate_fees` adiciona taxa conforme regras
+- [ ] Respeitar frete grátis acima de X
+- [ ] Testes com distâncias 0 / média / fora do raio
+
+---
+
+## 3) GEO & Mapas
+- [ ] **Explorar**: GPS (`assets/explore.js`) e markers (`assets/explore-map.js`)
+- [ ] **Restaurante**: mapa único (`assets/restaurant-map.js`)
+- [ ] **Checkout**: GPS (`assets/checkout-geo.js`) + Buscar endereço + reverse (`assets/geo-address.js`)
+- [ ] **Cache GEO**: usar `vc_geo_cache_*` para consultas Nominatim (por query e por lat:lng)
+- [ ] **Tiles**: URL configurável por filtro/opção (Mapbox/OSM)
+- [ ] Enqueue condicional: carregar Leaflet/mapas só onde necessário
+
+---
+
+## 4) KDS & REST — v0.6.2
+- [ ] REST: `GET /vemcomer/v1/orders?rid=` (lista por status)
+- [ ] REST: `POST /vemcomer/v1/orders/{id}/status` (confirm/prepare/out/delivered/cancel)
+- [ ] `assets/kds.js` consome `VC_KDS` (rest, nonce, rid, poll)
+- [ ] Poll configurável (`vemcomer_kds_poll`)
+- [ ] Beep opcional (toggle)
+- [ ] Testes ponta-a-ponta: criar pedido → mudar status no KDS → refletir no pedido
+
+---
+
+## 5) Checkout & UX — v0.6.1
+- [ ] Substituir `alert()` por mensagens inline (aria-live) no checkout e explorar
+- [ ] Campos extras: forma de pagamento offline, troco, observações
+- [ ] Validação: método entrega/retirada; endereço/lat-lng obrigatórios quando entrega
+- [ ] Persistir lat/lng na sessão (`woocommerce_after_checkout_validation`)
+- [ ] Texto claro de pagamento **na entrega** (Pix/cartão/dinheiro)
+
+---
+
+## 6) Settings (Admin) — v0.6.1
+- [ ] Página `Configurações → VemComer`
+- [ ] Campos:
+  - [ ] Tiles URL
+  - [ ] Raio padrão (km)
+  - [ ] KDS Poll (ms)
+  - [ ] Frete base
+  - [ ] Frete por km
+  - [ ] Frete grátis acima de
+  - [ ] Textos de pagamento offline (checkout)
+- [ ] `update_option()` + saneamento; carregamento com defaults via filtros
+
+---
+
+## 7) Favoritos & Histórico
+- [ ] Conferir shortcodes `[vc_favorites]`, `[vc_favorite_button]`, `[vc_customer_history]`
+- [ ] Garantir segurança (nonce) e redirecionamento pós-ação
+- [ ] Otimizar queries (ordenar por `post__in`, limitar itens)
+
+---
+
+## 8) Automations/Webhooks — v0.6.3
+- [ ] Hooks internos em mudanças de status de pedido (`woocommerce_order_status_changed`)
+- [ ] Filtro `vemcomer_order_webhook_payload` para customização do payload
+- [ ] Integração opcional com Automator/SMClick (sem gateway online)
+- [ ] Logs de envio e idempotência básica
+
+---
+
+## 9) Relatórios — v0.6.3
+- [ ] Sumários (admin/seller): pedidos por período, ticket médio, top itens
+- [ ] Export CSV simples
+- [ ] Restringir por restaurante (seller só vê o seu)
+
+---
+
+## 10) Acessibilidade & SEO — v0.6.4
+- [ ] Mensagens com `role="status"`/`aria-live="polite"`
+- [ ] Foco ao abrir feedback/erros
+- [ ] Schema: Organization, LocalBusiness/Restaurant, Product
+- [ ] Titles/Meta básicos nas páginas-chave
+
+---
+
+## 11) Performance — v0.6.4
+- [ ] Carregar scripts apenas quando necessários (shortcodes)
+- [ ] Minificar JS/CSS (build simples ou `.min` estático)
+- [ ] LCP < 2,5s em páginas principais
+- [ ] Revisão de polling KDS × tráfego (avaliar SSE/WebSocket futuramente)
+
+---
+
+## 12) DevX & CI
+- [ ] README com “onde mexer” + “como validar”
+- [ ] `docs/` com guia de edição e testes de aceitação
+- [ ] GitHub Actions (lint/PHPCS básico) — opcional
+- [ ] Fluxo WP Pusher (Push-to-Deploy) documentado
+
+---
+
+## 13) Testes de aceitação (sempre)
+- [ ] Pedido completo (explorar → menu → add to cart → checkout)
+- [ ] Single-seller: impedir mistura
+- [ ] Fechado: não comprável
+- [ ] GEO: GPS + busca por endereço atualizam lat/lng e taxa
+- [ ] KDS: pedidos aparecem e mudam de coluna ao alterar status
+- [ ] Logs: `wp-content/debug.log` sem fatals/warnings recorrentes
+
+---
+
+## 🔁 Depois de cada entrega
+- [ ] Bump de versão (`Version:` + `VEMCOMER_CORE_VERSION`)
+- [ ] Commit em `main`
+- [ ] WP Admin → WP Pusher → **Update plugin**
+- [ ] Limpar cache; se preciso, desativar/ativar plugin

--- a/inc/Admin/Settings.php
+++ b/inc/Admin/Settings.php
@@ -18,7 +18,6 @@ class Settings {
         add_action( 'admin_menu', [ $this, 'ensure_menu' ], 20 );
     }
 
-    /** Garante que a página de Configurações exista como submenu (caso não tenha o pacote 1) */
     public function ensure_menu(): void {
         add_submenu_page( 'vemcomer-root', __( 'Configurações', 'vemcomer' ), __( 'Configurações', 'vemcomer' ), 'manage_options', self::PAGE_SLUG, [ $this, 'render_page' ] );
     }
@@ -33,6 +32,8 @@ class Settings {
         add_settings_field( 'payment_provider', __( 'Gateway de Pagamento', 'vemcomer' ), [ $this, 'field_payment_provider' ], self::PAGE_SLUG, 'vc_general' );
         add_settings_field( 'payment_secret', __( 'Segredo do Webhook (HMAC)', 'vemcomer' ), [ $this, 'field_payment_secret' ], self::PAGE_SLUG, 'vc_general' );
         add_settings_field( 'delivery_provider', __( 'Serviço de Entrega', 'vemcomer' ), [ $this, 'field_delivery_provider' ], self::PAGE_SLUG, 'vc_general' );
+
+        add_settings_field( 'enable_wc_sync', __( 'Sincronizar com WooCommerce', 'vemcomer' ), [ $this, 'field_enable_wc_sync' ], self::PAGE_SLUG, 'vc_general' );
     }
 
     public function sanitize( $input ): array {
@@ -40,6 +41,7 @@ class Settings {
         $out['payment_provider']  = isset( $input['payment_provider'] ) ? sanitize_text_field( wp_unslash( $input['payment_provider'] ) ) : '';
         $out['payment_secret']    = isset( $input['payment_secret'] ) ? sanitize_text_field( wp_unslash( $input['payment_secret'] ) ) : '';
         $out['delivery_provider'] = isset( $input['delivery_provider'] ) ? sanitize_text_field( wp_unslash( $input['delivery_provider'] ) ) : '';
+        $out['enable_wc_sync']    = ! empty( $input['enable_wc_sync'] ) ? '1' : '';
         return $out;
     }
 
@@ -48,6 +50,7 @@ class Settings {
             'payment_provider'  => '',
             'payment_secret'    => '',
             'delivery_provider' => '',
+            'enable_wc_sync'    => '',
         ];
         return wp_parse_args( (array) get_option( self::OPTION_NAME, [] ), $defaults );
     }
@@ -78,5 +81,9 @@ class Settings {
     public function field_delivery_provider(): void {
         $o = $this->get();
         $this->text( 'delivery_provider', (string) $o['delivery_provider'], 'text', 'ex.: loggi, lalamove' );
+    }
+    public function field_enable_wc_sync(): void {
+        $o = $this->get();
+        echo '<label><input type="checkbox" name="' . esc_attr( self::OPTION_NAME . '[enable_wc_sync]' ) . '" value="1" ' . checked( (bool) $o['enable_wc_sync'], true, false ) . ' /> ' . esc_html__( 'Ativar sincronização com WooCommerce', 'vemcomer' ) . '</label>';
     }
 }

--- a/inc/Integration/WooCommerce.php
+++ b/inc/Integration/WooCommerce.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * WooCommerce — Integração básica (espelho de pedido e sync de status)
+ * @package VemComerCore
+ */
+
+namespace VC\Integration;
+
+use VC_CPT_Pedido;
+
+if ( ! defined( 'ABSPATH' ) ) { exit; }
+
+class WooCommerce {
+    public function init(): void {
+        // Sincroniza mudança de status do WooCommerce para VC
+        add_action( 'woocommerce_order_status_changed', [ $this, 'sync_status' ], 10, 4 );
+        // Garante espelho VC quando um pedido é criado no WC e ainda não há vínculo
+        add_action( 'woocommerce_checkout_order_processed', [ $this, 'maybe_mirror_order' ], 10, 3 );
+    }
+
+    /**
+     * Mapeia status do Woo para status VC
+     */
+    private function map_wc_to_vc( string $wc_status ): string {
+        return match ( $wc_status ) {
+            'processing' => 'vc-paid',
+            'completed'  => 'vc-completed',
+            'cancelled'  => 'vc-cancelled',
+            'on-hold'    => 'vc-pending',
+            default      => 'vc-pending',
+        };
+    }
+
+    public function sync_status( int $order_id, string $old_status, string $new_status, $order ): void {
+        $vc_id = (int) get_post_meta( $order_id, '_vc_pedido_id', true );
+        if ( ! $vc_id ) {
+            // Sem vínculo? tenta criar um espelho
+            $vc_id = $this->create_mirror_from_wc( $order_id );
+        }
+        if ( $vc_id ) {
+            $this->set_vc_status( $vc_id, $this->map_wc_to_vc( $new_status ) );
+        }
+    }
+
+    public function maybe_mirror_order( int $order_id, array $posted_data, $order ): void {
+        if ( (int) get_post_meta( $order_id, '_vc_pedido_id', true ) ) { return; }
+        $this->create_mirror_from_wc( $order_id );
+    }
+
+    private function create_mirror_from_wc( int $order_id ): int {
+        if ( ! function_exists( 'wc_get_order' ) ) { return 0; }
+        $order = wc_get_order( $order_id );
+        if ( ! $order ) { return 0; }
+
+        $items = [];
+        foreach ( $order->get_items() as $item ) {
+            $items[] = [
+                'product_id' => (int) $item->get_product_id(),
+                'name'       => (string) $item->get_name(),
+                'qty'        => (int) $item->get_quantity(),
+                'total'      => (string) $item->get_total(),
+            ];
+        }
+
+        $vc_id = wp_insert_post([
+            'post_type'   => VC_CPT_Pedido::SLUG,
+            'post_title'  => 'WC #' . $order_id,
+            'post_status' => 'vc-pending',
+        ]);
+        if ( is_wp_error( $vc_id ) ) { return 0; }
+
+        update_post_meta( $vc_id, '_vc_itens', $items );
+        update_post_meta( $vc_id, '_vc_total', (string) $order->get_total() );
+
+        // vínculo cruzado
+        update_post_meta( $order_id, '_vc_pedido_id', $vc_id );
+        update_post_meta( $vc_id, '_vc_linked_wc_order', $order_id );
+
+        /** Gatilho para Automator */
+        do_action( 'vemcomer/order_status_changed', $vc_id, 'vc-pending', 'new' );
+
+        return (int) $vc_id;
+    }
+
+    private function set_vc_status( int $vc_id, string $status ): void {
+        global $wpdb;
+        $old = get_post_status( $vc_id );
+        if ( $old === $status ) { return; }
+        $wpdb->update( $wpdb->posts, [ 'post_status' => $status ], [ 'ID' => $vc_id ] );
+        clean_post_cache( $vc_id );
+        do_action( 'vemcomer/order_status_changed', $vc_id, $status, $old );
+        if ( 'vc-paid' === $status ) {
+            do_action( 'vemcomer/order_paid', $vc_id );
+        }
+    }
+}

--- a/inc/Order/Statuses.php
+++ b/inc/Order/Statuses.php
@@ -63,10 +63,16 @@ class Statuses {
         if ( isset( $_POST['vc_order_status_sel'] ) ) {
             $new = sanitize_text_field( wp_unslash( $_POST['vc_order_status_sel'] ) );
             if ( isset( self::STATUSES[ $new ] ) ) {
-                // muda o post_status sem alterar a data
                 global $wpdb;
-                $wpdb->update( $wpdb->posts, [ 'post_status' => $new ], [ 'ID' => $post_id ] );
-                clean_post_cache( $post_id );
+                $old = get_post_status( $post_id );
+                if ( $new !== $old ) {
+                    $wpdb->update( $wpdb->posts, [ 'post_status' => $new ], [ 'ID' => $post_id ] );
+                    clean_post_cache( $post_id );
+                    do_action( 'vemcomer/order_status_changed', $post_id, $new, $old );
+                    if ( 'vc-paid' === $new ) {
+                        do_action( 'vemcomer/order_paid', $post_id );
+                    }
+                }
             }
         }
     }

--- a/vemcomer-core.php
+++ b/vemcomer-core.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * Plugin Name: VemComer Core
- * Description: Core do marketplace VemComer — CPTs, Admin e REST base.
- * Version: 0.3.0
+ * Description: Core do marketplace VemComer — CPTs, Admin, REST, Integrações.
+ * Version: 0.4.0
  * Requires at least: 6.0
  * Requires PHP: 8.0
  * Author: VemComer
@@ -11,7 +11,7 @@
 
 if ( ! defined( 'ABSPATH' ) ) { exit; }
 
-define( 'VEMCOMER_CORE_VERSION', '0.3.0' );
+define( 'VEMCOMER_CORE_VERSION', '0.4.0' );
 
 define( 'VEMCOMER_CORE_FILE', __FILE__ );
 
@@ -40,10 +40,8 @@ spl_autoload_register( function ( $class ) {
 require_once VEMCOMER_CORE_DIR . 'inc/helpers-sanitize.php';
 
 add_action( 'plugins_loaded', function () {
-    // Loader central
-    if ( class_exists( 'VC_Loader' ) ) { ( new \VC_Loader() )->init(); }
-
     // Pacote 1
+    if ( class_exists( 'VC_Loader' ) ) { ( new \VC_Loader() )->init(); }
     if ( class_exists( 'VC_CPT_Produto' ) ) { ( new \VC_CPT_Produto() )->init(); }
     if ( class_exists( 'VC_CPT_Pedido' ) )  { ( new \VC_CPT_Pedido() )->init(); }
     if ( class_exists( 'VC_Admin_Menu' ) )  { ( new \VC_Admin_Menu() )->init(); }
@@ -60,4 +58,14 @@ add_action( 'plugins_loaded', function () {
     if ( class_exists( '\\VC\\Order\\Statuses' ) )            { ( new \VC\Order\Statuses() )->init(); }
     if ( class_exists( '\\VC\\REST\\Webhooks_Controller' ) )  { ( new \VC\REST\Webhooks_Controller() )->init(); }
     if ( class_exists( '\\VC\\CLI\\Seed' ) )                  { ( new \VC\CLI\Seed() )->init(); }
+
+    // Pacote 4 — Integrações
+    // WooCommerce (opcional e controlado por setting)
+    if ( class_exists( '\\VC\\Integration\\WooCommerce' ) ) {
+        $settings = get_option( 'vemcomer_settings', [] );
+        $enabled  = ! empty( $settings['enable_wc_sync'] );
+        if ( $enabled && class_exists( 'WooCommerce' ) ) {
+            ( new \VC\Integration\WooCommerce() )->init();
+        }
+    }
 } );


### PR DESCRIPTION
## Summary
- add a WooCommerce integration that mirrors Woo orders into VemComer and keeps statuses in sync
- expose Automator-friendly hooks when order statuses change or are paid
- update plugin settings/bootstrap and docs, including the README and checklist relocation

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68df4e33bb70832bb5d43a3bd9769f32