### PR TITLE
feat: add persistent cart, coupons, and order emails

### DIFF
--- a/assets/css/frontend.css
+++ b/assets/css/frontend.css
@@ -13,3 +13,8 @@
 .vc-summary{margin-top:12px}
 .vc-summary>div{margin:4px 0}
 .vc-zip{width:160px;margin-left:8px}
+/* Pacote 6 */
+.vc-qbtn{border:1px solid #ddd;background:#fff;border-radius:6px;padding:2px 8px;margin:0 6px}
+.vc-qtd{display:flex;align-items:center;gap:4px}
+.vc-status-banner{background:#111;color:#fff;padding:8px 12px;border-radius:8px;margin-top:8px;display:inline-block}
+.vc-discount{margin-top:4px}

--- a/assets/js/frontend.js
+++ b/assets/js/frontend.js
@@ -1,8 +1,8 @@
 (function(){
+  // ===== Utilidades de moeda =====
   function currencyToFloat(v){
     if(typeof v !== 'string') return Number(v||0);
     v = v.replace(/[^0-9,\.]/g,'');
-    // tenta formato brasileiro
     if(v.indexOf(',')>-1 && v.lastIndexOf(',')>v.lastIndexOf('.')){
       v = v.replace(/\./g,'').replace(',', '.');
     }
@@ -12,27 +12,68 @@
     return (Number(n)||0).toFixed(2).replace('.', ',');
   }
 
-  const cart = [];
+  // ===== Carrinho persistente =====
+  const CART_KEY = 'vc_cart_v1';
+  const cart = JSON.parse(localStorage.getItem(CART_KEY) || '[]');
+  function saveCart(){ localStorage.setItem(CART_KEY, JSON.stringify(cart)); }
+
+  // ===== UI: render de carrinho =====
   function renderCart(root){
-    const list = cart.map(i=>`<div class="vc-row"><span>${i.title}</span><div>x${i.qtd}</div><div>R$ ${floatToBR(i.qtd*currencyToFloat(i.price))}</div></div>`).join('');
+    const list = cart.map(i=>`<div class="vc-row"><span>${i.title}</span><div class="vc-qtd"><button class="vc-qbtn vc-dec" data-id="${i.id}">-</button><span>${i.qtd}</span><button class="vc-qbtn vc-inc" data-id="${i.id}">+</button></div><div>R$ ${floatToBR(i.qtd*currencyToFloat(i.price))}</div></div>`).join('');
     const subtotal = cart.reduce((s,i)=> s + i.qtd*currencyToFloat(i.price), 0);
     root.querySelector('.vc-cart').innerHTML = list || '<div class="vc-empty">Carrinho vazio</div>';
     root.querySelector('.vc-subtotal').innerHTML = `Subtotal: <strong>R$ ${floatToBR(subtotal)}</strong>`;
     root.dataset.subtotal = String(subtotal);
+    const has = cart.length>0; const place = root.querySelector('.vc-place-order'); if(place) place.disabled = !has;
   }
 
+  // ===== Cupom simples =====
+  const COUPON_KEY = 'vc_coupon_v1';
+  function applyCoupon(code, subtotal){
+    code = (code||'').trim().toUpperCase();
+    if(!code) return {ok:false, msg:'Cupom vazio.'};
+    // Regras simples (poderá vir de REST no futuro)
+    const rules = {
+      'DESC10': { type:'percent', value:10 },
+      'DESC5':  { type:'money', value:5.00 },
+      'FRETEGRATIS': { type:'freight', value:1 }
+    };
+    const r = rules[code];
+    if(!r) return {ok:false, msg:'Cupom inválido.'};
+    let discount = 0, freightFree = false;
+    if(r.type==='percent') discount = subtotal * (r.value/100);
+    if(r.type==='money') discount = r.value;
+    if(r.type==='freight') freightFree = true;
+    return {ok:true, code, discount, freightFree};
+  }
+
+  // ===== Eventos globais =====
   document.addEventListener('click', function(e){
     const add = e.target.closest('.vc-add');
     if(add){
       const id  = Number(add.dataset.id);
       const rid = Number(add.dataset.restaurant);
-      const title = add.dataset.title;
-      const price = add.dataset.price;
+      const title = add.dataset.title; const price = add.dataset.price;
       const found = cart.find(i=>i.id===id);
       if(found) found.qtd++; else cart.push({id, rid, title, price, qtd:1});
+      saveCart();
       const checkout = document.querySelector('.vc-checkout');
       if(checkout) renderCart(checkout);
     }
+  });
+
+  document.addEventListener('click', function(e){
+    const dec = e.target.closest('.vc-dec');
+    const inc = e.target.closest('.vc-inc');
+    if(!dec && !inc) return;
+    const id = Number((dec||inc).dataset.id);
+    const found = cart.find(i=>i.id===id); if(!found) return;
+    if(dec){ found.qtd = Math.max(0, found.qtd-1); }
+    if(inc){ found.qtd++; }
+    for(let i=cart.length-1;i>=0;i--){ if(cart[i].qtd===0) cart.splice(i,1); }
+    saveCart();
+    const checkout = document.querySelector('.vc-checkout');
+    if(checkout) renderCart(checkout);
   });
 
   document.addEventListener('click', async function(e){
@@ -40,17 +81,26 @@
     if(!btn) return;
     const root = btn.closest('.vc-checkout');
     const rid = Number(root.dataset.restaurant||0) || (cart[0] && cart[0].rid) || 0;
-    const zip = root.querySelector('.vc-zip').value;
     const subtotal = Number(root.dataset.subtotal||0);
-    if(!rid){ alert('Selecione itens de um restaurante.'); return; }
+
+    const coupon = (root.querySelector('.vc-coupon')?.value||'').trim().toUpperCase();
+    const c = applyCoupon(coupon, subtotal);
     const url = `${VemComer.rest.base}/shipping/quote?restaurant_id=${rid}&subtotal=${subtotal}`;
-    const res = await fetch(url);
-    const data = await res.json();
-    root.dataset.ship = String(data.ship||0);
-    root.querySelector('.vc-quote-result').innerHTML = data.free ? 'Frete grátis' : `Frete: R$ ${floatToBR(data.ship)}`;
-    root.querySelector('.vc-freight').innerHTML = `Frete: <strong>R$ ${floatToBR(data.ship||0)}</strong>`;
-    const total = subtotal + Number(data.ship||0);
+    const res = await fetch(url); const shipData = await res.json();
+    let ship = Number(shipData.ship||0);
+    if(c.ok && c.freightFree) ship = 0;
+
+    const discount = c.ok ? (c.discount||0) : 0;
+    const total = Math.max(0, subtotal - discount + ship);
+
+    root.querySelector('.vc-quote-result').innerHTML = shipData.free || (c.ok && c.freightFree) ? 'Frete grátis' : `Frete: R$ ${floatToBR(ship)}`;
+    root.querySelector('.vc-freight').innerHTML = `Frete: <strong>R$ ${floatToBR(ship)}</strong>`;
+    root.querySelector('.vc-discount').innerHTML = c.ok ? `Desconto: <strong>- R$ ${floatToBR(discount)}</strong>` : '';
     root.querySelector('.vc-total').innerHTML = `Total: <strong>R$ ${floatToBR(total)}</strong>`;
+
+    root.dataset.ship = String(ship);
+    root.dataset.discount = String(discount);
+    if(c.ok) localStorage.setItem(COUPON_KEY, coupon); else localStorage.removeItem(COUPON_KEY);
     root.querySelector('.vc-place-order').disabled = cart.length===0;
   });
 
@@ -60,30 +110,61 @@
     const root = btn.closest('.vc-checkout');
     const subtotal = Number(root.dataset.subtotal||0);
     const ship = Number(root.dataset.ship||0);
-    const total = subtotal + ship;
+    const discount = Number(root.dataset.discount||0);
+    const total = Math.max(0, subtotal - discount + ship);
 
     const itens = cart.map(i=>({ produto_id: i.id, qtd: i.qtd }));
+    const payload = { itens, total: floatToBR(total) };
     const res = await fetch(`${VemComer.rest.base}/pedidos`,{
-      method:'POST',
-      headers:{'Content-Type':'application/json','X-WP-Nonce': VemComer.nonce},
-      body: JSON.stringify({ itens, total: floatToBR(total) })
+      method:'POST', headers:{'Content-Type':'application/json','X-WP-Nonce': VemComer.nonce}, body: JSON.stringify(payload)
     });
     const data = await res.json();
     if(data && data.id){
-      root.querySelector('.vc-order-result').innerHTML = `Pedido criado #${data.id}`;
-      cart.length = 0; renderCart(root);
+      root.querySelector('.vc-order-result').innerHTML = `Pedido criado #${data.id}. <button class="vc-btn vc-track" data-id="${data.id}">Acompanhar</button>`;
+      cart.length = 0; saveCart(); renderCart(root);
       root.querySelector('.vc-freight').innerHTML='';
       root.querySelector('.vc-total').innerHTML='';
       root.querySelector('.vc-quote-result').innerHTML='';
+      root.querySelector('.vc-discount').innerHTML='';
       root.querySelector('.vc-place-order').disabled = true;
     } else {
       alert('Falha ao criar pedido');
     }
   });
 
+  // ===== Acompanhamento (polling) =====
+  let trackingTimer = null;
+  async function pollStatus(orderId, box){
+    const url = `${VemComer.rest.base}/orders/${orderId}`;
+    try{
+      const r = await fetch(url); const j = await r.json();
+      if(j && j.id){
+        box.innerHTML = `<div class="vc-status-banner">Status: <strong>${j.status_label||j.status}</strong></div>`;
+        if(['vc-completed','vc-cancelled'].includes(j.status)){
+          clearInterval(trackingTimer); trackingTimer = null;
+        }
+      }
+    }catch(err){ /* silencioso */ }
+  }
+
+  document.addEventListener('click', function(e){
+    const t = e.target.closest('.vc-track');
+    if(!t) return;
+    const id = Number(t.dataset.id);
+    const root = t.closest('.vc-checkout');
+    const box = root.querySelector('.vc-order-result');
+    if(trackingTimer) clearInterval(trackingTimer);
+    pollStatus(id, box); // imediato
+    trackingTimer = setInterval(()=>pollStatus(id, box), 5000);
+  });
+
   // Render inicial se existir checkout na página
   window.addEventListener('DOMContentLoaded', ()=>{
     const checkout = document.querySelector('.vc-checkout');
-    if(checkout) renderCart(checkout);
+    if(checkout) {
+      renderCart(checkout);
+      const coupon = localStorage.getItem(COUPON_KEY)||'';
+      const input = document.querySelector('.vc-coupon'); if(input) input.value = coupon;
+    }
   });
 })();

--- a/inc/Admin/Settings.php
+++ b/inc/Admin/Settings.php
@@ -34,6 +34,8 @@ class Settings {
         add_settings_field( 'delivery_provider', __( 'Serviço de Entrega', 'vemcomer' ), [ $this, 'field_delivery_provider' ], self::PAGE_SLUG, 'vc_general' );
 
         add_settings_field( 'enable_wc_sync', __( 'Sincronizar com WooCommerce', 'vemcomer' ), [ $this, 'field_enable_wc_sync' ], self::PAGE_SLUG, 'vc_general' );
+        add_settings_field( 'email_enabled', __( 'Enviar emails de eventos', 'vemcomer' ), [ $this, 'field_email_enabled' ], self::PAGE_SLUG, 'vc_general' );
+        add_settings_field( 'email_from', __( 'Remetente (email)', 'vemcomer' ), [ $this, 'field_email_from' ], self::PAGE_SLUG, 'vc_general' );
     }
 
     public function sanitize( $input ): array {
@@ -42,6 +44,8 @@ class Settings {
         $out['payment_secret']    = isset( $input['payment_secret'] ) ? sanitize_text_field( wp_unslash( $input['payment_secret'] ) ) : '';
         $out['delivery_provider'] = isset( $input['delivery_provider'] ) ? sanitize_text_field( wp_unslash( $input['delivery_provider'] ) ) : '';
         $out['enable_wc_sync']    = ! empty( $input['enable_wc_sync'] ) ? '1' : '';
+        $out['email_enabled']     = ! empty( $input['email_enabled'] ) ? '1' : '';
+        $out['email_from']        = isset( $input['email_from'] ) ? sanitize_email( $input['email_from'] ) : '';
         return $out;
     }
 
@@ -51,6 +55,8 @@ class Settings {
             'payment_secret'    => '',
             'delivery_provider' => '',
             'enable_wc_sync'    => '',
+            'email_enabled'     => '',
+            'email_from'        => '',
         ];
         return wp_parse_args( (array) get_option( self::OPTION_NAME, [] ), $defaults );
     }
@@ -85,5 +91,16 @@ class Settings {
     public function field_enable_wc_sync(): void {
         $o = $this->get();
         echo '<label><input type="checkbox" name="' . esc_attr( self::OPTION_NAME . '[enable_wc_sync]' ) . '" value="1" ' . checked( (bool) $o['enable_wc_sync'], true, false ) . ' /> ' . esc_html__( 'Ativar sincronização com WooCommerce', 'vemcomer' ) . '</label>';
+    }
+    public function field_email_enabled(): void {
+        $o = $this->get();
+        echo '<label><input type="checkbox" name="' . esc_attr( self::OPTION_NAME . '[email_enabled]' ) . '" value="1" ' . checked( (bool) $o['email_enabled'], true, false ) . ' /> ' . esc_html__( 'Ativar emails (admin)', 'vemcomer' ) . '</label>';
+    }
+    public function field_email_from(): void {
+        $o = $this->get();
+        echo '<input type="email" class="regular-text" name="' . esc_attr( self::OPTION_NAME . '[email_from]' ) . '" value="' . esc_attr( (string) $o['email_from'] ) . '" placeholder="admin@exemplo.com" />';
+        add_filter( 'wp_mail_from', static function ( $from ) use ( $o ) {
+            return ! empty( $o['email_from'] ) ? $o['email_from'] : $from;
+        } );
     }
 }

--- a/inc/Email/Events.php
+++ b/inc/Email/Events.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Events — Dispara emails em eventos de pedido
+ * @package VemComerCore
+ */
+
+namespace VC\Email;
+
+use VC\Admin\Settings;
+
+if ( ! defined( 'ABSPATH' ) ) { exit; }
+
+class Events {
+    public function init(): void {
+        add_action( 'vemcomer/order_paid', [ $this, 'email_order_paid' ], 10, 1 );
+        add_action( 'vemcomer/order_status_changed', [ $this, 'email_status_changed' ], 10, 3 );
+    }
+
+    private function can_send(): bool {
+        $o = ( new Settings() )->get();
+        return ! empty( $o['email_enabled'] );
+    }
+
+    private function send( string $to, string $subject, string $html ): void {
+        $callback = static function () {
+            return 'text/html';
+        };
+        add_filter( 'wp_mail_content_type', $callback );
+        wp_mail( $to, $subject, $html );
+        remove_filter( 'wp_mail_content_type', $callback );
+    }
+
+    public function email_order_paid( int $order_id ): void {
+        if ( ! $this->can_send() ) { return; }
+        $to = get_option( 'admin_email' );
+        $title = sprintf( __( 'Pedido #%d pago', 'vemcomer' ), $order_id );
+        $body  = Template::wrap( $title, '<p>' . esc_html__( 'Recebemos a confirmação de pagamento.', 'vemcomer' ) . '</p>' );
+        $this->send( $to, $title, $body );
+    }
+
+    public function email_status_changed( int $order_id, string $new, string $old ): void {
+        if ( ! $this->can_send() ) { return; }
+        $to = get_option( 'admin_email' );
+        $title = sprintf( __( 'Pedido #%d mudou para %s', 'vemcomer' ), $order_id, $new );
+        $body  = Template::wrap( $title, '<p>' . esc_html__( 'Status atualizado no painel.', 'vemcomer' ) . '</p>' );
+        $this->send( $to, $title, $body );
+    }
+}

--- a/inc/Email/Template.php
+++ b/inc/Email/Template.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Template — Helpers de email HTML simples
+ * @package VemComerCore
+ */
+
+namespace VC\Email;
+
+if ( ! defined( 'ABSPATH' ) ) { exit; }
+
+class Template {
+    public static function wrap( string $title, string $body ): string {
+        $styles = 'font-family:Arial,Helvetica,sans-serif;max-width:560px;margin:0 auto;border:1px solid #eee;border-radius:10px;overflow:hidden';
+        $header = '<div style="background:#111;color:#fff;padding:14px 18px"><strong>VemComer</strong></div>';
+        $h1 = '<h2 style="margin:16px 0 8px">' . esc_html( $title ) . '</h2>';
+        $inner = '<div style="padding:16px">' . $h1 . '<div>' . wp_kses_post( $body ) . '</div></div>';
+        $footer = '<div style="background:#fafafa;color:#777;padding:10px 16px;font-size:12px">&copy; ' . wp_date('Y') . ' VemComer</div>';
+        return '<div style="' . esc_attr( $styles ) . '">' . $header . $inner . $footer . '</div>';
+    }
+}

--- a/inc/REST/Orders_Controller.php
+++ b/inc/REST/Orders_Controller.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Orders_Controller — Status e resumo de pedido
+ * @route GET /wp-json/vemcomer/v1/orders/{id}
+ * @package VemComerCore
+ */
+
+namespace VC\REST;
+
+use WP_REST_Request;
+use WP_Error;
+
+if ( ! defined( 'ABSPATH' ) ) { exit; }
+
+class Orders_Controller {
+    public function init(): void {
+        add_action( 'rest_api_init', [ $this, 'routes' ] );
+    }
+
+    public function routes(): void {
+        register_rest_route( 'vemcomer/v1', '/orders/(?P<id>\\d+)', [
+            'methods'             => 'GET',
+            'callback'            => [ $this, 'get_order' ],
+            'permission_callback' => '__return_true',
+        ] );
+    }
+
+    public function get_order( WP_REST_Request $req ) {
+        $id = (int) $req['id'];
+        if ( $id <= 0 ) {
+            return new WP_Error( 'vc_bad_id', __( 'ID inválido.', 'vemcomer' ), [ 'status' => 400 ] );
+        }
+        $post = get_post( $id );
+        if ( ! $post || 'vc_pedido' !== $post->post_type ) {
+            return new WP_Error( 'vc_not_found', __( 'Pedido não encontrado.', 'vemcomer' ), [ 'status' => 404 ] );
+        }
+        $status = get_post_status( $post );
+        $map = [
+            'vc-pending'    => __( 'Pendente', 'vemcomer' ),
+            'vc-paid'       => __( 'Pago', 'vemcomer' ),
+            'vc-preparing'  => __( 'Preparando', 'vemcomer' ),
+            'vc-delivering' => __( 'Em entrega', 'vemcomer' ),
+            'vc-completed'  => __( 'Concluído', 'vemcomer' ),
+            'vc-cancelled'  => __( 'Cancelado', 'vemcomer' ),
+        ];
+        return rest_ensure_response([
+            'id'           => $post->ID,
+            'status'       => $status,
+            'status_label' => $map[ $status ] ?? $status,
+            'total'        => (string) get_post_meta( $post->ID, '_vc_total', true ),
+            'itens'        => (array) get_post_meta( $post->ID, '_vc_itens', true ),
+        ]);
+    }
+}

--- a/vemcomer-core.php
+++ b/vemcomer-core.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * Plugin Name: VemComer Core
- * Description: Core do marketplace VemComer — CPTs, Admin, REST, Frontend e Frete.
- * Version: 0.5.0
+ * Description: Core do marketplace VemComer — UX+ (carrinho, cupons, tracking e emails)
+ * Version: 0.6.0
  * Requires at least: 6.0
  * Requires PHP: 8.0
  * Author: VemComer
@@ -11,7 +11,7 @@
 
 if ( ! defined( 'ABSPATH' ) ) { exit; }
 
-define( 'VEMCOMER_CORE_VERSION', '0.5.0' );
+define( 'VEMCOMER_CORE_VERSION', '0.6.0' );
 
 define( 'VEMCOMER_CORE_FILE', __FILE__ );
 
@@ -19,7 +19,7 @@ define( 'VEMCOMER_CORE_DIR', plugin_dir_path( __FILE__ ) );
 
 define( 'VEMCOMER_CORE_URL', plugin_dir_url( __FILE__ ) );
 
-// Autoload legado VC_*
+// autoloads (legado + PSR-4) — mesmos dos pacotes anteriores
 spl_autoload_register( function ( $class ) {
     if ( str_starts_with( $class, 'VC_' ) ) {
         $path = VEMCOMER_CORE_DIR . 'inc/' . 'class-' . strtolower( str_replace( '_', '-', $class ) ) . '.php';
@@ -27,7 +27,6 @@ spl_autoload_register( function ( $class ) {
     }
 } );
 
-// Autoload PSR-4 (namespace VC\*)
 spl_autoload_register( function ( $class ) {
     if ( str_starts_with( $class, 'VC\\' ) ) {
         $relative = str_replace( 'VC\\', '', $class );
@@ -40,27 +39,25 @@ spl_autoload_register( function ( $class ) {
 require_once VEMCOMER_CORE_DIR . 'inc/helpers-sanitize.php';
 
 add_action( 'plugins_loaded', function () {
-    // Pacote 1
+    // (carrega tudo dos pacotes 1 a 5 como antes)
     if ( class_exists( 'VC_Loader' ) ) { ( new \VC_Loader() )->init(); }
     if ( class_exists( 'VC_CPT_Produto' ) ) { ( new \VC_CPT_Produto() )->init(); }
     if ( class_exists( 'VC_CPT_Pedido' ) )  { ( new \VC_CPT_Pedido() )->init(); }
     if ( class_exists( 'VC_Admin_Menu' ) )  { ( new \VC_Admin_Menu() )->init(); }
     if ( class_exists( 'VC_REST' ) )        { ( new \VC_REST() )->init(); }
-
-    // Pacote 2
     if ( class_exists( '\\VC\\Model\\CPT_Restaurant' ) )      { ( new \VC\Model\CPT_Restaurant() )->init(); }
     if ( class_exists( '\\VC\\Model\\CPT_MenuItem' ) )        { ( new \VC\Model\CPT_MenuItem() )->init(); }
     if ( class_exists( '\\VC\\Admin\\Menu_Restaurant' ) )     { ( new \VC\Admin\Menu_Restaurant() )->init(); }
     if ( class_exists( '\\VC\\REST\\Restaurant_Controller' ) ) { ( new \VC\REST\Restaurant_Controller() )->init(); }
-
-    // Pacote 3
     if ( class_exists( '\\VC\\Admin\\Settings' ) )            { ( new \VC\Admin\Settings() )->init(); }
     if ( class_exists( '\\VC\\Order\\Statuses' ) )            { ( new \VC\Order\Statuses() )->init(); }
     if ( class_exists( '\\VC\\REST\\Webhooks_Controller' ) )  { ( new \VC\REST\Webhooks_Controller() )->init(); }
     if ( class_exists( '\\VC\\CLI\\Seed' ) )                  { ( new \VC\CLI\Seed() )->init(); }
-
-    // Pacote 5 — Frontend
     if ( class_exists( '\\VC\\Frontend\\Shortcodes' ) )        { ( new \VC\Frontend\Shortcodes() )->init(); }
     if ( class_exists( '\\VC\\Frontend\\Shipping' ) )          { ( new \VC\Frontend\Shipping() )->init(); }
     if ( class_exists( '\\VC\\REST\\Shipping_Controller' ) )   { ( new \VC\REST\Shipping_Controller() )->init(); }
+
+    // Pacote 6 — Orders REST + Emails
+    if ( class_exists( '\\VC\\REST\\Orders_Controller' ) )     { ( new \VC\REST\Orders_Controller() )->init(); }
+    if ( class_exists( '\\VC\\Email\\Events' ) )               { ( new \VC\Email\Events() )->init(); }
 } );


### PR DESCRIPTION
## Summary
- add persistent cart experience with coupon handling, freight calculation, and order tracking polling on the frontend
- expose a REST endpoint to fetch order status and summary data
- introduce HTML email templates, event-driven notifications, and admin settings for enabling and configuring sender details
- update the plugin bootstrap to load the new REST and email components

## Testing
- php -l inc/REST/Orders_Controller.php
- php -l inc/Email/Template.php
- php -l inc/Email/Events.php


------
https://chatgpt.com/codex/tasks/task_b_68df5206492c832b9ac102423a6688de