### PR TITLE
Add admin reports, CSV export, and REST caching

### DIFF
--- a/inc/Admin/Export.php
+++ b/inc/Admin/Export.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Export — Exportação CSV de pedidos
+ * @package VemComerCore
+ */
+
+namespace VC\Admin;
+
+if ( ! defined( 'ABSPATH' ) ) { exit; }
+
+class Export {
+    public function init(): void {
+        add_action( 'admin_post_vc_export_orders', [ $this, 'export_orders' ] );
+    }
+
+    public function export_orders(): void {
+        if ( ! current_user_can( 'manage_options' ) ) { wp_die( __( 'Sem permissão.', 'vemcomer' ) ); }
+        check_admin_referer( 'vc_export_orders' );
+
+        $from = isset( $_GET['from'] ) ? sanitize_text_field( wp_unslash( $_GET['from'] ) ) : wp_date( 'Y-m-01' );
+        $to   = isset( $_GET['to'] )   ? sanitize_text_field( wp_unslash( $_GET['to'] ) )   : wp_date( 'Y-m-d' );
+
+        $args = [
+            'post_type'      => 'vc_pedido',
+            'post_status'    => 'any',
+            'date_query'     => [ [ 'after' => $from . ' 00:00:00', 'before' => $to . ' 23:59:59', 'inclusive' => true ] ],
+            'posts_per_page' => -1,
+            'fields'         => 'ids',
+            'no_found_rows'  => true,
+        ];
+        $q = new \WP_Query( $args );
+        $ids = $q->posts ?: [];
+
+        nocache_headers();
+        header( 'Content-Type: text/csv; charset=utf-8' );
+        header( 'Content-Disposition: attachment; filename=vemcomer-orders-' . $from . '_to_' . $to . '.csv' );
+
+        $out = fopen( 'php://output', 'w' );
+        fputcsv( $out, [ 'id', 'status', 'created_at', 'total', 'items_json' ] );
+        foreach ( $ids as $id ) {
+            $status = get_post_status( $id );
+            $date   = get_post_field( 'post_date', $id );
+            $total  = (string) get_post_meta( $id, '_vc_total', true );
+            $items  = (array) get_post_meta( $id, '_vc_itens', true );
+            fputcsv( $out, [ $id, $status, $date, $total, wp_json_encode( $items ) ] );
+        }
+        fclose( $out );
+        exit;
+    }
+}

--- a/inc/Admin/Reports.php
+++ b/inc/Admin/Reports.php
@@ -1,0 +1,120 @@
+<?php
+/**
+ * Reports — Relatórios administrativos do VemComer
+ * @package VemComerCore
+ */
+
+namespace VC\Admin;
+
+if ( ! defined( 'ABSPATH' ) ) { exit; }
+
+class Reports {
+    public function init(): void {
+        add_action( 'admin_menu', [ $this, 'menu' ], 30 );
+    }
+
+    public function menu(): void {
+        add_submenu_page( 'vemcomer-root', __( 'Relatórios', 'vemcomer' ), __( 'Relatórios', 'vemcomer' ), 'manage_options', 'vemcomer-reports', [ $this, 'render' ] );
+    }
+
+    private function range(): array {
+        $from = isset( $_GET['from'] ) ? sanitize_text_field( wp_unslash( $_GET['from'] ) ) : wp_date( 'Y-m-01' );
+        $to   = isset( $_GET['to'] )   ? sanitize_text_field( wp_unslash( $_GET['to'] ) )   : wp_date( 'Y-m-d' );
+        return [ $from, $to ];
+    }
+
+    private function query_orders( string $from, string $to, array $statuses = [] ): array {
+        global $wpdb;
+        $post_type = 'vc_pedido';
+        $statuses_sql = '';
+        if ( $statuses ) {
+            $in = implode( ',', array_map( fn($s)=> $wpdb->prepare( '%s', $s ), $statuses ) );
+            $statuses_sql = "AND p.post_status IN ($in)";
+        }
+        $sql = $wpdb->prepare(
+            "SELECT p.ID, p.post_status, p.post_date, pm.meta_value AS total
+             FROM {$wpdb->posts} p
+             LEFT JOIN {$wpdb->postmeta} pm ON pm.post_id = p.ID AND pm.meta_key = '_vc_total'
+             WHERE p.post_type = %s AND p.post_date BETWEEN %s AND %s $statuses_sql",
+            $post_type,
+            $from . ' 00:00:00',
+            $to . ' 23:59:59'
+        );
+        $rows = $wpdb->get_results( $sql, ARRAY_A );
+        return $rows ?: [];
+    }
+
+    private function sum( array $orders ): float {
+        $t = 0.0; foreach ( $orders as $o ) { $t += (float) str_replace( ',', '.', (string) ( $o['total'] ?? 0 ) ); } return $t;
+    }
+
+    private function count_by_status( array $orders ): array {
+        $out = [];
+        foreach ( $orders as $o ) { $st = (string) $o['post_status']; $out[$st] = ($out[$st] ?? 0) + 1; }
+        return $out;
+    }
+
+    private function counts(): array {
+        $restaurants = wp_count_posts( 'vc_restaurant' );
+        $menu_items  = wp_count_posts( 'vc_menu_item' );
+        return [
+            'restaurants' => array_sum( (array) $restaurants ),
+            'menu_items'  => array_sum( (array) $menu_items ),
+        ];
+    }
+
+    public function render(): void {
+        [ $from, $to ] = $this->range();
+        $orders = $this->query_orders( $from, $to, [] );
+        $total  = $this->sum( $orders );
+        $bySt   = $this->count_by_status( $orders );
+        $cts    = $this->counts();
+
+        echo '<div class="wrap"><h1>' . esc_html__( 'Relatórios', 'vemcomer' ) . '</h1>';
+        echo '<form method="get" style="margin: 10px 0 20px 0">';
+        echo '<input type="hidden" name="page" value="vemcomer-reports" />';
+        echo '<label>De <input type="date" name="from" value="' . esc_attr( $from ) . '"></label> ';
+        echo '<label>Até <input type="date" name="to" value="' . esc_attr( $to ) . '"></label> ';
+        submit_button( __( 'Filtrar', 'vemcomer' ), 'secondary', '', false );
+        echo ' <a class="button" href="' . esc_url( wp_nonce_url( admin_url( 'admin-post.php?action=vc_export_orders&from=' . $from . '&to=' . $to ), 'vc_export_orders' ) ) . '">' . esc_html__( 'Exportar CSV', 'vemcomer' ) . '</a>';
+        echo '</form>';
+
+        echo '<div class="vc-report-cards" style="display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:12px">';
+        echo '<div class="card" style="border:1px solid #e6e6e6;border-radius:10px;padding:12px"><strong>' . esc_html__( 'Pedidos (total)', 'vemcomer' ) . ':</strong> ' . esc_html( (string) count( $orders ) ) . '</div>';
+        echo '<div class="card" style="border:1px solid #e6e6e6;border-radius:10px;padding:12px"><strong>' . esc_html__( 'Faturamento', 'vemcomer' ) . ':</strong> R$ ' . esc_html( number_format( $total, 2, ',', '.' ) ) . '</div>';
+        echo '<div class="card" style="border:1px solid #e6e6e6;border-radius:10px;padding:12px"><strong>' . esc_html__( 'Restaurantes', 'vemcomer' ) . ':</strong> ' . esc_html( (string) $cts['restaurants'] ) . '</div>';
+        echo '<div class="card" style="border:1px solid #e6e6e6;border-radius:10px;padding:12px"><strong>' . esc_html__( 'Itens do cardápio', 'vemcomer' ) . ':</strong> ' . esc_html( (string) $cts['menu_items'] ) . '</div>';
+        echo '</div>';
+
+        echo '<h2 style="margin-top:20px">' . esc_html__( 'Pedidos por status', 'vemcomer' ) . '</h2>';
+        echo '<table class="widefat"><thead><tr><th>Status</th><th>Qtde</th></tr></thead><tbody>';
+        $status_labels = [
+            'vc-pending'    => __( 'Pendente', 'vemcomer' ),
+            'vc-paid'       => __( 'Pago', 'vemcomer' ),
+            'vc-preparing'  => __( 'Preparando', 'vemcomer' ),
+            'vc-delivering' => __( 'Em entrega', 'vemcomer' ),
+            'vc-completed'  => __( 'Concluído', 'vemcomer' ),
+            'vc-cancelled'  => __( 'Cancelado', 'vemcomer' ),
+        ];
+        foreach ( $status_labels as $key => $label ) {
+            $q = (int) ( $bySt[ $key ] ?? 0 );
+            echo '<tr><td>' . esc_html( $label ) . '</td><td>' . esc_html( (string) $q ) . '</td></tr>';
+        }
+        echo '</tbody></table>';
+
+        echo '<h2 style="margin-top:20px">' . esc_html__( 'Pedidos no período', 'vemcomer' ) . '</h2>';
+        echo '<table class="widefat"><thead><tr><th>ID</th><th>Data</th><th>Status</th><th>Total</th></tr></thead><tbody>';
+        foreach ( $orders as $o ) {
+            echo '<tr>';
+            echo '<td><a href="' . esc_url( get_edit_post_link( (int) $o['ID'] ) ) . '">#' . esc_html( (string) $o['ID'] ) . '</a></td>';
+            echo '<td>' . esc_html( (string) $o['post_date'] ) . '</td>';
+            echo '<td>' . esc_html( (string) $o['post_status'] ) . '</td>';
+            $tot = number_format( (float) str_replace( ',', '.', (string) $o['total'] ), 2, ',', '.' );
+            echo '<td>R$ ' . esc_html( $tot ) . '</td>';
+            echo '</tr>';
+        }
+        echo '</tbody></table>';
+
+        echo '</div>';
+    }
+}

--- a/inc/REST/Cache_Middleware.php
+++ b/inc/REST/Cache_Middleware.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * Cache_Middleware — Cache de endpoints públicos via transients
+ * Aplica cache a requisições GET em rotas:
+ *  - /vemcomer/v1/restaurants
+ *  - /vemcomer/v1/restaurants/{id}/menu-items
+ * TTL padrão: 60s (filtro: vemcomer/rest_cache_ttl)
+ * @package VemComerCore
+ */
+
+namespace VC\REST;
+
+use WP_REST_Request;
+use WP_REST_Response;
+
+if ( ! defined( 'ABSPATH' ) ) { exit; }
+
+class Cache_Middleware {
+    public function init(): void {
+        add_filter( 'rest_request_before_callbacks', [ $this, 'maybe_serve_cache' ], 10, 3 );
+        add_filter( 'rest_request_after_callbacks',  [ $this, 'maybe_store_cache' ], 10, 3 );
+    }
+
+    private function is_cacheable_route( string $route ): bool {
+        return (bool) preg_match( '#^/vemcomer/v1/restaurants(?:/\d+/menu-items)?$#', $route );
+    }
+
+    private function key_for( WP_REST_Request $request ): string {
+        $route = $request->get_route();
+        $params = $request->get_params();
+        ksort( $params );
+        return 'vc_rest_cache_' . md5( $route . '|' . wp_json_encode( $params ) );
+    }
+
+    public function maybe_serve_cache( $response, array $handler, WP_REST_Request $request ) {
+        if ( 'GET' !== $request->get_method() ) { return $response; }
+        $route = $request->get_route();
+        if ( ! $this->is_cacheable_route( $route ) ) { return $response; }
+        $key = $this->key_for( $request );
+        $cached = get_transient( $key );
+        if ( false !== $cached ) {
+            return new WP_REST_Response( $cached, 200 );
+        }
+        return $response; // segue para os callbacks normais
+    }
+
+    public function maybe_store_cache( $response, array $handler, WP_REST_Request $request ) {
+        if ( 'GET' !== $request->get_method() ) { return $response; }
+        $route = $request->get_route();
+        if ( ! $this->is_cacheable_route( $route ) ) { return $response; }
+        if ( is_wp_error( $response ) ) { return $response; }
+
+        $ttl = (int) apply_filters( 'vemcomer/rest_cache_ttl', 60, $route, $request );
+        $key = $this->key_for( $request );
+
+        // Extrai os dados do response
+        $data = ( $response instanceof WP_REST_Response ) ? $response->get_data() : $response;
+        set_transient( $key, $data, $ttl );
+        return $response;
+    }
+}

--- a/inc/REST/Invalidation.php
+++ b/inc/REST/Invalidation.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Invalidation — Invalidação simples do cache quando restaurantes/itens mudam
+ * @package VemComerCore
+ */
+
+namespace VC\REST;
+
+if ( ! defined( 'ABSPATH' ) ) { exit; }
+
+class Invalidation {
+    public function init(): void {
+        // Sempre que salvar restaurante ou item do cardápio, limpa transients relacionados
+        add_action( 'save_post_vc_restaurant', [ $this, 'flush_all' ] );
+        add_action( 'save_post_vc_menu_item', [ $this, 'flush_all' ] );
+        add_action( 'deleted_post', [ $this, 'flush_all' ] );
+        add_action( 'trashed_post', [ $this, 'flush_all' ] );
+    }
+
+    public function flush_all(): void {
+        global $wpdb;
+        $wpdb->query( "DELETE FROM {$wpdb->options} WHERE option_name LIKE '_transient_vc_rest_cache_%' OR option_name LIKE '_transient_timeout_vc_rest_cache_%'" );
+    }
+}

--- a/vemcomer-core.php
+++ b/vemcomer-core.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * Plugin Name: VemComer Core
- * Description: Core do marketplace VemComer — CPTs, Admin, REST, Frontend e Frete.
- * Version: 0.5.0
+ * Description: Core do marketplace VemComer — Relatórios, Export CSV e Cache de endpoints
+ * Version: 0.7.0
  * Requires at least: 6.0
  * Requires PHP: 8.0
  * Author: VemComer
@@ -11,7 +11,7 @@
 
 if ( ! defined( 'ABSPATH' ) ) { exit; }
 
-define( 'VEMCOMER_CORE_VERSION', '0.5.0' );
+define( 'VEMCOMER_CORE_VERSION', '0.7.0' );
 
 define( 'VEMCOMER_CORE_FILE', __FILE__ );
 
@@ -40,27 +40,35 @@ spl_autoload_register( function ( $class ) {
 require_once VEMCOMER_CORE_DIR . 'inc/helpers-sanitize.php';
 
 add_action( 'plugins_loaded', function () {
-    // Pacote 1
+    // Carrega módulos já existentes (Pacotes 1..6) — mantidos como estavam
     if ( class_exists( 'VC_Loader' ) ) { ( new \VC_Loader() )->init(); }
     if ( class_exists( 'VC_CPT_Produto' ) ) { ( new \VC_CPT_Produto() )->init(); }
     if ( class_exists( 'VC_CPT_Pedido' ) )  { ( new \VC_CPT_Pedido() )->init(); }
     if ( class_exists( 'VC_Admin_Menu' ) )  { ( new \VC_Admin_Menu() )->init(); }
     if ( class_exists( 'VC_REST' ) )        { ( new \VC_REST() )->init(); }
 
-    // Pacote 2
     if ( class_exists( '\\VC\\Model\\CPT_Restaurant' ) )      { ( new \VC\Model\CPT_Restaurant() )->init(); }
     if ( class_exists( '\\VC\\Model\\CPT_MenuItem' ) )        { ( new \VC\Model\CPT_MenuItem() )->init(); }
     if ( class_exists( '\\VC\\Admin\\Menu_Restaurant' ) )     { ( new \VC\Admin\Menu_Restaurant() )->init(); }
     if ( class_exists( '\\VC\\REST\\Restaurant_Controller' ) ) { ( new \VC\REST\Restaurant_Controller() )->init(); }
 
-    // Pacote 3
     if ( class_exists( '\\VC\\Admin\\Settings' ) )            { ( new \VC\Admin\Settings() )->init(); }
     if ( class_exists( '\\VC\\Order\\Statuses' ) )            { ( new \VC\Order\Statuses() )->init(); }
     if ( class_exists( '\\VC\\REST\\Webhooks_Controller' ) )  { ( new \VC\REST\Webhooks_Controller() )->init(); }
     if ( class_exists( '\\VC\\CLI\\Seed' ) )                  { ( new \VC\CLI\Seed() )->init(); }
 
-    // Pacote 5 — Frontend
     if ( class_exists( '\\VC\\Frontend\\Shortcodes' ) )        { ( new \VC\Frontend\Shortcodes() )->init(); }
     if ( class_exists( '\\VC\\Frontend\\Shipping' ) )          { ( new \VC\Frontend\Shipping() )->init(); }
     if ( class_exists( '\\VC\\REST\\Shipping_Controller' ) )   { ( new \VC\REST\Shipping_Controller() )->init(); }
+    if ( class_exists( '\\VC\\Frontend\\Coupons' ) )           { ( new \VC\Frontend\Coupons() )->init(); }
+    if ( class_exists( '\\VC\\REST\\Coupons_Controller' ) )    { ( new \VC\REST\Coupons_Controller() )->init(); }
+    if ( class_exists( '\\VC\\REST\\Orders_Controller' ) )     { ( new \VC\REST\Orders_Controller() )->init(); }
+    if ( class_exists( '\\VC\\Email\\Templates' ) )            { ( new \VC\Email\Templates() )->init(); }
+    if ( class_exists( '\\VC\\Email\\Events' ) )               { ( new \VC\Email\Events() )->init(); }
+
+    // Pacote 7 — Admin Reports, Export e Cache
+    if ( class_exists( '\\VC\\Admin\\Reports' ) )              { ( new \VC\Admin\Reports() )->init(); }
+    if ( class_exists( '\\VC\\Admin\\Export' ) )               { ( new \VC\Admin\Export() )->init(); }
+    if ( class_exists( '\\VC\\REST\\Cache_Middleware' ) )      { ( new \VC\REST\Cache_Middleware() )->init(); }
+    if ( class_exists( '\\VC\\REST\\Invalidation' ) )          { ( new \VC\REST\Invalidation() )->init(); }
 } );


### PR DESCRIPTION
## Summary
- add admin reports page with filtering, totals, and CSV export link
- implement secure CSV export for orders scoped by date range
- add REST API caching middleware with invalidation for restaurant and menu item changes
- bump plugin bootstrap to version 0.7.0 and load new modules

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68df52fc3524832b98e05c323024cf53