### PR TITLE
Add restaurants CPT, taxonomies, and admin UI

### DIFF
--- a/assets/css/restaurants-admin.css
+++ b/assets/css/restaurants-admin.css
@@ -1,0 +1,10 @@
+/* Estilos simples para a metabox */
+#vc_restaurant_info .form-table th {
+  width: 220px;
+}
+
+#vc_restaurant_info .form-table input[type="text"],
+#vc_restaurant_info .form-table input[type="url"],
+#vc_restaurant_info .form-table textarea {
+  max-width: 520px;
+}

--- a/assets/js/restaurants-admin.js
+++ b/assets/js/restaurants-admin.js
@@ -1,0 +1,15 @@
+(function($){
+  $(function(){
+    // Pequena melhoria UX: aviso de CNPJ duplicado na tela de edição
+    const $cnpj = $('#vc_restaurant_cnpj');
+    $cnpj.on('blur', function(){
+      const val = $(this).val().trim();
+      if(!val) return;
+      // Somente validação de formato básico; validação de duplicidade exigiria endpoint REST/busca
+      const justNums = val.replace(/\D/g,'');
+      if(justNums.length < 14){
+        alert('CNPJ parece incompleto (14 dígitos).');
+      }
+    });
+  });
+})(jQuery);

--- a/inc/admin-columns.php
+++ b/inc/admin-columns.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Colunas de admin para o CPT Restaurantes
+ */
+
+if ( ! defined( 'ABSPATH' ) ) { exit; }
+
+add_filter( 'manage_vc_restaurant_posts_columns', function( $columns ) {
+    $new = [];
+    // Mantém checkbox e título
+    foreach ( $columns as $key => $label ) {
+        if ( in_array( $key, [ 'cb', 'title' ], true ) ) {
+            $new[ $key ] = $label;
+        }
+    }
+
+    $new['vc_cuisine']   = __( 'Cozinha', 'vemcomer' );
+    $new['vc_location']  = __( 'Bairro', 'vemcomer' );
+    $new['delivery']     = __( 'Delivery', 'vemcomer' );
+    $new['date']         = $columns['date'];
+
+    return $new;
+});
+
+add_action( 'manage_vc_restaurant_posts_custom_column', function( $column, $post_id ) {
+    if ( 'vc_cuisine' === $column ) {
+        echo esc_html( join( ', ', wp_get_post_terms( $post_id, 'vc_cuisine', [ 'fields' => 'names' ] ) ) );
+    }
+    if ( 'vc_location' === $column ) {
+        echo esc_html( join( ', ', wp_get_post_terms( $post_id, 'vc_location', [ 'fields' => 'names' ] ) ) );
+    }
+    if ( 'delivery' === $column ) {
+        $val = get_post_meta( $post_id, VC_META_RESTAURANT_FIELDS['delivery'], true );
+        echo $val === '1' ? '✓' : '—';
+    }
+}, 10, 2 );

--- a/inc/init-restaurants.php
+++ b/inc/init-restaurants.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Bootstrap do módulo de Restaurantes do VemComer Core
+ *
+ * Carrega CPT, taxonomias, metaboxes e colunas administrativas.
+ */
+
+// Impede acesso direto.
+if ( ! defined( 'ABSPATH' ) ) { exit; }
+
+require_once __DIR__ . '/post-types.php';
+require_once __DIR__ . '/taxonomies.php';
+require_once __DIR__ . '/meta-restaurants.php';
+require_once __DIR__ . '/admin-columns.php';
+
+// Assets de admin (opcional)
+add_action( 'admin_enqueue_scripts', function( $hook ) {
+    // Carrega apenas nas telas do CPT de restaurantes
+    $screen = get_current_screen();
+    if ( isset( $screen->post_type ) && 'vc_restaurant' === $screen->post_type ) {
+        wp_enqueue_script(
+            'vc-restaurants-admin',
+            plugins_url( '../assets/js/restaurants-admin.js', __FILE__ ),
+            [ 'jquery' ],
+            defined('VEMCOMER_CORE_VERSION') ? VEMCOMER_CORE_VERSION : '1.0.0',
+            true
+        );
+        wp_enqueue_style(
+            'vc-restaurants-admin',
+            plugins_url( '../assets/css/restaurants-admin.css', __FILE__ ),
+            [],
+            defined('VEMCOMER_CORE_VERSION') ? VEMCOMER_CORE_VERSION : '1.0.0'
+        );
+    }
+});

--- a/inc/meta-restaurants.php
+++ b/inc/meta-restaurants.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * Metaboxes e salvamento seguro para Restaurantes
+ */
+
+if ( ! defined( 'ABSPATH' ) ) { exit; }
+
+// Chaves de meta
+const VC_META_RESTAURANT_FIELDS = [
+    'cnpj'        => 'vc_restaurant_cnpj',
+    'whatsapp'    => 'vc_restaurant_whatsapp',
+    'site'        => 'vc_restaurant_site',
+    'open_hours'  => 'vc_restaurant_open_hours',
+    'delivery'    => 'vc_restaurant_delivery', // bool
+    'address'     => 'vc_restaurant_address',
+];
+
+add_action( 'add_meta_boxes', function() {
+    add_meta_box(
+        'vc_restaurant_info',
+        __( 'Informações do restaurante', 'vemcomer' ),
+        'vc_render_restaurant_metabox',
+        'vc_restaurant',
+        'normal',
+        'high'
+    );
+});
+
+function vc_render_restaurant_metabox( $post ) {
+    wp_nonce_field( 'vc_restaurant_meta_nonce', 'vc_restaurant_meta_nonce_field' );
+
+    $values = [];
+    foreach ( VC_META_RESTAURANT_FIELDS as $key => $meta_key ) {
+        $values[ $key ] = get_post_meta( $post->ID, $meta_key, true );
+    }
+    ?>
+    <table class="form-table">
+        <tr>
+            <th><label for="vc_restaurant_cnpj"><?php echo esc_html__( 'CNPJ', 'vemcomer' ); ?></label></th>
+            <td><input type="text" id="vc_restaurant_cnpj" name="vc_restaurant_cnpj" class="regular-text" value="<?php echo esc_attr( $values['cnpj'] ); ?>" /></td>
+        </tr>
+        <tr>
+            <th><label for="vc_restaurant_whatsapp"><?php echo esc_html__( 'WhatsApp', 'vemcomer' ); ?></label></th>
+            <td><input type="text" id="vc_restaurant_whatsapp" name="vc_restaurant_whatsapp" class="regular-text" placeholder="55 11 99999-9999" value="<?php echo esc_attr( $values['whatsapp'] ); ?>" /></td>
+        </tr>
+        <tr>
+            <th><label for="vc_restaurant_site"><?php echo esc_html__( 'Site', 'vemcomer' ); ?></label></th>
+            <td><input type="url" id="vc_restaurant_site" name="vc_restaurant_site" class="regular-text" value="<?php echo esc_attr( $values['site'] ); ?>" /></td>
+        </tr>
+        <tr>
+            <th><label for="vc_restaurant_open_hours"><?php echo esc_html__( 'Horário de funcionamento', 'vemcomer' ); ?></label></th>
+            <td><textarea id="vc_restaurant_open_hours" name="vc_restaurant_open_hours" class="large-text" rows="3"><?php echo esc_textarea( $values['open_hours'] ); ?></textarea></td>
+        </tr>
+        <tr>
+            <th><label for="vc_restaurant_delivery"><?php echo esc_html__( 'Entrega (delivery)', 'vemcomer' ); ?></label></th>
+            <td><label><input type="checkbox" id="vc_restaurant_delivery" name="vc_restaurant_delivery" value="1" <?php checked( $values['delivery'], '1' ); ?> /> <?php echo esc_html__( 'Oferece delivery', 'vemcomer' ); ?></label></td>
+        </tr>
+        <tr>
+            <th><label for="vc_restaurant_address"><?php echo esc_html__( 'Endereço', 'vemcomer' ); ?></label></th>
+            <td><input type="text" id="vc_restaurant_address" name="vc_restaurant_address" class="regular-text" value="<?php echo esc_attr( $values['address'] ); ?>" /></td>
+        </tr>
+    </table>
+    <?php
+}
+
+add_action( 'save_post_vc_restaurant', function( $post_id ) {
+    // Verificações de segurança
+    if ( ! isset( $_POST['vc_restaurant_meta_nonce_field'] ) ) return;
+    if ( ! wp_verify_nonce( $_POST['vc_restaurant_meta_nonce_field'], 'vc_restaurant_meta_nonce' ) ) return;
+    if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) return;
+    if ( ! current_user_can( 'edit_post', $post_id ) ) return;
+
+    // Sanitização e salvamento
+    update_post_meta( $post_id, VC_META_RESTAURANT_FIELDS['cnpj'], sanitize_text_field( $_POST['vc_restaurant_cnpj'] ?? '' ) );
+    update_post_meta( $post_id, VC_META_RESTAURANT_FIELDS['whatsapp'], sanitize_text_field( $_POST['vc_restaurant_whatsapp'] ?? '' ) );
+    update_post_meta( $post_id, VC_META_RESTAURANT_FIELDS['site'], esc_url_raw( $_POST['vc_restaurant_site'] ?? '' ) );
+    update_post_meta( $post_id, VC_META_RESTAURANT_FIELDS['open_hours'], wp_kses_post( $_POST['vc_restaurant_open_hours'] ?? '' ) );
+    update_post_meta( $post_id, VC_META_RESTAURANT_FIELDS['delivery'], isset( $_POST['vc_restaurant_delivery'] ) ? '1' : '0' );
+    update_post_meta( $post_id, VC_META_RESTAURANT_FIELDS['address'], sanitize_text_field( $_POST['vc_restaurant_address'] ?? '' ) );
+});

--- a/inc/post-types.php
+++ b/inc/post-types.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Registro do Custom Post Type: Restaurantes
+ */
+
+if ( ! defined( 'ABSPATH' ) ) { exit; }
+
+add_action( 'init', function() {
+    $labels = [
+        'name'                  => __( 'Restaurantes', 'vemcomer' ),
+        'singular_name'         => __( 'Restaurante', 'vemcomer' ),
+        'menu_name'             => __( 'Restaurantes', 'vemcomer' ),
+        'name_admin_bar'        => __( 'Restaurante', 'vemcomer' ),
+        'add_new'               => __( 'Adicionar novo', 'vemcomer' ),
+        'add_new_item'          => __( 'Adicionar novo restaurante', 'vemcomer' ),
+        'new_item'              => __( 'Novo restaurante', 'vemcomer' ),
+        'edit_item'             => __( 'Editar restaurante', 'vemcomer' ),
+        'view_item'             => __( 'Ver restaurante', 'vemcomer' ),
+        'all_items'             => __( 'Todos os restaurantes', 'vemcomer' ),
+        'search_items'          => __( 'Buscar restaurantes', 'vemcomer' ),
+        'parent_item_colon'     => __( 'Restaurante pai:', 'vemcomer' ),
+        'not_found'             => __( 'Nenhum restaurante encontrado.', 'vemcomer' ),
+        'not_found_in_trash'    => __( 'Nenhum restaurante na lixeira.', 'vemcomer' ),
+        'featured_image'        => __( 'Imagem destacada', 'vemcomer' ),
+        'set_featured_image'    => __( 'Definir imagem destacada', 'vemcomer' ),
+        'remove_featured_image' => __( 'Remover imagem destacada', 'vemcomer' ),
+        'use_featured_image'    => __( 'Usar como imagem destacada', 'vemcomer' ),
+        'archives'              => __( 'Arquivo de restaurantes', 'vemcomer' ),
+        'insert_into_item'      => __( 'Inserir no restaurante', 'vemcomer' ),
+        'uploaded_to_this_item' => __( 'Enviado para este restaurante', 'vemcomer' ),
+        'filter_items_list'     => __( 'Filtrar lista de restaurantes', 'vemcomer' ),
+        'items_list_navigation' => __( 'Navegação de lista de restaurantes', 'vemcomer' ),
+        'items_list'            => __( 'Lista de restaurantes', 'vemcomer' ),
+    ];
+
+    $capabilities = [
+        'edit_post'          => 'edit_vc_restaurant',
+        'read_post'          => 'read_vc_restaurant',
+        'delete_post'        => 'delete_vc_restaurant',
+        'edit_posts'         => 'edit_vc_restaurants',
+        'edit_others_posts'  => 'edit_others_vc_restaurants',
+        'delete_posts'       => 'delete_vc_restaurants',
+        'publish_posts'      => 'publish_vc_restaurants',
+        'read_private_posts' => 'read_private_vc_restaurants',
+    ];
+
+    $args = [
+        'labels'             => $labels,
+        'public'             => true,
+        'show_in_menu'       => true,
+        'menu_icon'          => 'dashicons-store',
+        'supports'           => [ 'title', 'editor', 'thumbnail', 'excerpt' ],
+        'has_archive'        => true,
+        'rewrite'            => [ 'slug' => 'restaurantes' ],
+        'capability_type'    => [ 'vc_restaurant', 'vc_restaurants' ],
+        'map_meta_cap'       => true,
+        'capabilities'       => $capabilities,
+        'show_in_rest'       => true,
+    ];
+
+    register_post_type( 'vc_restaurant', $args );
+});

--- a/inc/taxonomies.php
+++ b/inc/taxonomies.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Taxonomias do CPT Restaurantes
+ * - Tipo de Cozinha (hierárquica)
+ * - Bairro/Localização (não hierárquica)
+ */
+
+if ( ! defined( 'ABSPATH' ) ) { exit; }
+
+add_action( 'init', function() {
+    // Tipo de Cozinha
+    register_taxonomy( 'vc_cuisine', [ 'vc_restaurant' ], [
+        'labels' => [
+            'name'          => __( 'Tipos de cozinha', 'vemcomer' ),
+            'singular_name' => __( 'Tipo de cozinha', 'vemcomer' ),
+        ],
+        'hierarchical' => true,
+        'show_admin_column' => true,
+        'rewrite' => [ 'slug' => 'cozinha' ],
+        'show_in_rest' => true,
+    ]);
+
+    // Bairro / Localização
+    register_taxonomy( 'vc_location', [ 'vc_restaurant' ], [
+        'labels' => [
+            'name'          => __( 'Bairros', 'vemcomer' ),
+            'singular_name' => __( 'Bairro', 'vemcomer' ),
+        ],
+        'hierarchical' => false,
+        'show_admin_column' => true,
+        'rewrite' => [ 'slug' => 'bairro' ],
+        'show_in_rest' => true,
+    ]);
+});

--- a/vemcomer-core.php
+++ b/vemcomer-core.php
@@ -74,3 +74,9 @@ add_action( 'plugins_loaded', function () {
     // Pacote 8 — Instalador de Páginas
     if ( class_exists( '\\VC\\Admin\\Installer' ) )            { ( new \VC\Admin\Installer() )->init(); }
 } );
+
+// --- Bootstrap do módulo Restaurantes ---
+$vc_inc_base = VEMCOMER_CORE_DIR . 'inc/';
+if ( file_exists( $vc_inc_base . 'init-restaurants.php' ) ) {
+    require_once $vc_inc_base . 'init-restaurants.php';
+}


### PR DESCRIPTION
## Summary
- add restaurant module bootstrap registering CPT, taxonomies, meta boxes, and admin columns
- provide tailored admin assets for the restaurant editor experience
- load the restaurant module from the main plugin bootstrap

## Testing
- php -l vemcomer-core.php
- php -l inc/init-restaurants.php
- php -l inc/post-types.php
- php -l inc/taxonomies.php
- php -l inc/meta-restaurants.php
- php -l inc/admin-columns.php

------
https://chatgpt.com/codex/tasks/task_b_68df569b2508832ba468ecbf053ff9b8