### PR TITLE
Add centralized seeder and admin filler submenu

### DIFF
--- a/assets/css/preenchedor.css
+++ b/assets/css/preenchedor.css
@@ -1,0 +1,3 @@
+.vc-preenchedor .form-table th {
+    width: 260px;
+}

--- a/bin/wp-cli-seed-restaurants.php
+++ b/bin/wp-cli-seed-restaurants.php
@@ -1,116 +1,44 @@
 <?php
 /**
- * WP-CLI Seeder: Popula restaurantes de exemplo
- *
+ * WP-CLI: Preenchedor de Restaurantes (compatível com Admin Preenchedor)
  * Uso:
- *   wp vemcomer seed-restaurants --count=5 --force
+ *   wp vemcomer seed-restaurants --count=5 [--force]
  */
 
 if ( ! defined( 'WP_CLI' ) || ! WP_CLI ) { return; }
 
+require_once dirname( __DIR__ ) . '/inc/seed/Seeder.php';
+
 class VC_CLI_Seed_Restaurants {
-    /** @var array */
-    private $cuisines = [ 'pizza', 'japonesa', 'brasileira', 'hamburgueria', 'vegana' ];
-    /** @var array */
-    private $locations = [ 'centro', 'zona-sul', 'zona-norte', 'zona-leste', 'zona-oeste' ];
-
     /**
-     * Cria termos base caso não existam
-     */
-    private function ensure_terms() : void {
-        foreach ( $this->cuisines as $slug ) {
-            if ( ! term_exists( $slug, 'vc_cuisine' ) ) {
-                wp_insert_term( ucfirst( $slug ), 'vc_cuisine', [ 'slug' => $slug ] );
-            }
-        }
-        foreach ( $this->locations as $slug ) {
-            if ( ! term_exists( $slug, 'vc_location' ) ) {
-                wp_insert_term( ucwords( str_replace('-', ' ', $slug) ), 'vc_location', [ 'slug' => $slug ] );
-            }
-        }
-    }
-
-    /**
-     * Comando: wp vemcomer seed-restaurants
+     * Executa o seed.
      *
      * ## OPTIONS
-     * [--count=<n>]     Quantidade de restaurantes (padrão 5)
-     * [--force]         Recria mesmo se já houver posts
-     *
-     * ## EXAMPLES
-     *   wp vemcomer seed-restaurants --count=8
+     * [--count=<n>]  Quantidade (default 5)
+     * [--force]      Remove existentes antes
      */
     public function __invoke( $args, $assoc_args ) : void {
         $count = isset( $assoc_args['count'] ) ? max( 1, (int) $assoc_args['count'] ) : 5;
         $force = isset( $assoc_args['force'] );
 
-        // Garante CPT carregado
         if ( ! post_type_exists( 'vc_restaurant' ) ) {
-            WP_CLI::error( 'CPT vc_restaurant não está registrado. Ative o plugin/core.' );
+            \WP_CLI::error( 'CPT vc_restaurant não está registrado. Ative o módulo correspondente.' );
             return;
         }
 
-        $this->ensure_terms();
+        $seeder = new VC_Seeder();
+        $ids    = $seeder->seed_restaurants( $count, $force );
 
-        if ( ! $force ) {
-            $existing = (new WP_Query([
-                'post_type'      => 'vc_restaurant',
-                'posts_per_page' => 1,
-                'fields'         => 'ids',
-            ]))->posts;
-            if ( ! empty( $existing ) ) {
-                WP_CLI::warning( 'Já existem restaurantes. Use --force para recriar.' );
-                return;
-            }
+        if ( empty( $ids ) ) {
+            \WP_CLI::warning( 'Nenhum restaurante criado.' );
+            return;
         }
 
-        // Remove existentes quando --force
-        if ( $force ) {
-            $to_delete = (new WP_Query([
-                'post_type'      => 'vc_restaurant',
-                'posts_per_page' => -1,
-                'fields'         => 'ids',
-            ]))->posts;
-            foreach ( $to_delete as $pid ) {
-                wp_delete_post( $pid, true );
-            }
+        foreach ( $ids as $pid ) {
+            \WP_CLI::log( 'Criado restaurante ID ' . $pid );
         }
-
-        $faker_names = [ 'Cantina da Praça', 'Sushi do Bairro', 'Hamburgueria Fênix', 'Veg & Co', 'Pizzaria La Nonna', 'Sabores do Brasil' ];
-
-        for ( $i = 0; $i < $count; $i++ ) {
-            $title = $faker_names[ $i % count( $faker_names ) ] . ' #' . ($i+1);
-            $pid = wp_insert_post([
-                'post_type'   => 'vc_restaurant',
-                'post_title'  => $title,
-                'post_status' => 'publish',
-                'post_content'=> 'Restaurante de exemplo criado via seeder.'
-            ]);
-
-            if ( is_wp_error( $pid ) ) {
-                WP_CLI::warning( 'Falha ao criar restaurante: ' . $title );
-                continue;
-            }
-
-            // Termos aleatórios
-            $cuisine  = $this->cuisines[ array_rand( $this->cuisines ) ];
-            $location = $this->locations[ array_rand( $this->locations ) ];
-            wp_set_object_terms( $pid, $cuisine, 'vc_cuisine', false );
-            wp_set_object_terms( $pid, $location, 'vc_location', false );
-
-            // Metas
-            update_post_meta( $pid, 'vc_restaurant_cnpj', sprintf('00.000.000/%05d-00', rand( 100, 999 ) ) );
-            update_post_meta( $pid, 'vc_restaurant_whatsapp', '+55 11 9' . rand(1000,9999) . '-' . rand(1000,9999) );
-            update_post_meta( $pid, 'vc_restaurant_site', 'https://exemplo-' . ($i+1) . '.vemcomer.test' );
-            update_post_meta( $pid, 'vc_restaurant_open_hours', 'Seg-Dom 11:00–23:00' );
-            update_post_meta( $pid, 'vc_restaurant_delivery', rand(0,1) ? '1' : '0' );
-            update_post_meta( $pid, 'vc_restaurant_address', 'Rua Exemplo, ' . rand(10,999) . ' – ' . ucwords( str_replace('-', ' ', $location) ) );
-
-            WP_CLI::log( "Criado: {$title} (ID {$pid}) [{$cuisine} | {$location}]" );
-        }
-
-        WP_CLI::success( 'Seed finalizado.' );
+        \WP_CLI::success( 'Seed finalizado: ' . count( $ids ) . ' restaurantes.' );
     }
 }
 
-WP_CLI::add_command( 'vemcomer seed-restaurants', new VC_CLI_Seed_Restaurants() );
+\WP_CLI::add_command( 'vemcomer seed-restaurants', new VC_CLI_Seed_Restaurants() );

--- a/inc/admin/preenchedor.php
+++ b/inc/admin/preenchedor.php
@@ -1,0 +1,104 @@
+<?php
+/**
+ * Submenu Admin – Preenchedor de dados (seed) para testes
+ */
+
+if ( ! defined( 'ABSPATH' ) ) { exit; }
+
+require_once dirname( __DIR__ ) . '/seed/Seeder.php';
+
+add_action( 'admin_menu', static function() {
+    global $admin_page_hooks;
+    if ( ! isset( $admin_page_hooks['vemcomer-root'] ) ) {
+        add_menu_page( 'VemComer', 'VemComer', 'edit_posts', 'vemcomer-root', '__return_null', 'dashicons-store', 25 );
+    }
+    add_submenu_page( 'vemcomer-root', 'Preenchedor', 'Preenchedor', 'edit_posts', 'vc-preenchedor', 'vc_render_preenchedor' );
+});
+
+add_action( 'admin_enqueue_scripts', static function( $hook ) {
+    if ( 'vemcomer-root_page_vc-preenchedor' !== $hook ) {
+        return;
+    }
+
+    if ( defined( 'VEMCOMER_CORE_DIR' ) && file_exists( VEMCOMER_CORE_DIR . 'assets/css/preenchedor.css' ) ) {
+        wp_enqueue_style(
+            'vc-preenchedor',
+            defined( 'VEMCOMER_CORE_URL' ) ? VEMCOMER_CORE_URL . 'assets/css/preenchedor.css' : plugins_url( '../../assets/css/preenchedor.css', __FILE__ ),
+            [],
+            defined( 'VEMCOMER_CORE_VERSION' ) ? VEMCOMER_CORE_VERSION : '1.0.0'
+        );
+    }
+});
+
+function vc_render_preenchedor() {
+    if ( ! current_user_can( 'edit_posts' ) ) {
+        wp_die( __( 'Sem permissão.', 'vemcomer' ) );
+    }
+
+    $created_message = '';
+    $notice_class    = 'notice-success';
+
+    if ( isset( $_POST['vc_filler_nonce'] ) && wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['vc_filler_nonce'] ) ), 'vc_filler_action' ) ) {
+        $count_raw = isset( $_POST['vc_qtd_restaurantes'] ) ? sanitize_text_field( wp_unslash( $_POST['vc_qtd_restaurantes'] ) ) : '5';
+        $qtd       = max( 1, (int) $count_raw );
+        $with_items = isset( $_POST['vc_criar_itens'] );
+
+        $seeder = new VC_Seeder();
+        $ids    = $seeder->seed_restaurants( $qtd, ! empty( $_POST['vc_force'] ) );
+
+        $total_items = 0;
+        if ( $with_items ) {
+            foreach ( $ids as $rid ) {
+                $total_items += count( $seeder->seed_menu_items_for( $rid, 3, 6 ) );
+            }
+        }
+
+        if ( empty( $ids ) ) {
+            $created_message = __( 'Nenhum restaurante criado. Verifique se o CPT vc_restaurant está ativo.', 'vemcomer' );
+            $notice_class    = 'notice-warning';
+        } else {
+            $created_message = sprintf(
+                'Criados %d restaurantes%s.',
+                count( $ids ),
+                $with_items ? ' e ' . $total_items . ' itens' : ''
+            );
+        }
+    }
+    ?>
+    <div class="wrap vc-preenchedor">
+        <h1>Preenchedor de Dados</h1>
+        <?php if ( $created_message ) : ?>
+            <div class="notice <?php echo esc_attr( $notice_class ); ?>"><p><?php echo esc_html( $created_message ); ?></p></div>
+        <?php endif; ?>
+        <form method="post">
+            <?php wp_nonce_field( 'vc_filler_action', 'vc_filler_nonce' ); ?>
+            <table class="form-table">
+                <tr>
+                    <th><label for="vc-qtd-restaurantes">Quantidade de restaurantes</label></th>
+                    <td><input type="number" id="vc-qtd-restaurantes" name="vc_qtd_restaurantes" value="5" min="1" class="small-text" /></td>
+                </tr>
+                <tr>
+                    <th>Itens de cardápio</th>
+                    <td>
+                        <label>
+                            <input type="checkbox" name="vc_criar_itens" value="1" />
+                            Criar itens (3–6 por restaurante) <em>(se o CPT <code>vc_menu_item</code> existir)</em>
+                        </label>
+                    </td>
+                </tr>
+                <tr>
+                    <th>Forçar recriação</th>
+                    <td>
+                        <label>
+                            <input type="checkbox" name="vc_force" value="1" />
+                            Apagar existentes antes de criar
+                        </label>
+                    </td>
+                </tr>
+            </table>
+            <p><button class="button button-primary" type="submit">Executar</button></p>
+        </form>
+        <p class="description">Dica: você também pode usar via WP-CLI → <code>wp vemcomer seed-restaurants --count=5 --force</code></p>
+    </div>
+    <?php
+}

--- a/inc/init-restaurants.php
+++ b/inc/init-restaurants.php
@@ -12,6 +12,11 @@ require_once __DIR__ . '/admin-columns.php';
 require_once __DIR__ . '/rest-api.php';
 require_once __DIR__ . '/roles-capabilities.php';
 
+$preenchedor_file = __DIR__ . '/admin/preenchedor.php';
+if ( file_exists( $preenchedor_file ) ) {
+    require_once $preenchedor_file;
+}
+
 // Assets de admin
 add_action( 'admin_enqueue_scripts', function() {
     $screen = function_exists('get_current_screen') ? get_current_screen() : null;

--- a/inc/seed/Seeder.php
+++ b/inc/seed/Seeder.php
@@ -1,0 +1,134 @@
+<?php
+/**
+ * VemComer Core – Seeder centralizado
+ * Gera Restaurantes e (se existir) Itens de Cardápio
+ */
+
+if ( ! defined( 'ABSPATH' ) ) { exit; }
+
+class VC_Seeder {
+    /** Taxonomias default para seed */
+    private array $cuisines  = [ 'pizza', 'japonesa', 'brasileira', 'hamburgueria', 'vegana' ];
+    private array $locations = [ 'centro', 'zona-sul', 'zona-norte', 'zona-leste', 'zona-oeste' ];
+
+    /**
+     * Garante termos básicos de taxonomias do CPT de restaurantes.
+     */
+    public function ensure_terms(): void {
+        if ( taxonomy_exists( 'vc_cuisine' ) ) {
+            foreach ( $this->cuisines as $slug ) {
+                if ( ! term_exists( $slug, 'vc_cuisine' ) ) {
+                    wp_insert_term( ucfirst( $slug ), 'vc_cuisine', [ 'slug' => $slug ] );
+                }
+            }
+        }
+        if ( taxonomy_exists( 'vc_location' ) ) {
+            foreach ( $this->locations as $slug ) {
+                if ( ! term_exists( $slug, 'vc_location' ) ) {
+                    wp_insert_term( ucwords( str_replace( '-', ' ', $slug ) ), 'vc_location', [ 'slug' => $slug ] );
+                }
+            }
+        }
+    }
+
+    /**
+     * Cria N restaurantes com metadados e termos. Retorna array de IDs criados.
+     *
+     * @param int  $count Quantidade de restaurantes a gerar.
+     * @param bool $force Limpa existentes antes de criar.
+     *
+     * @return int[] IDs criados.
+     */
+    public function seed_restaurants( int $count = 5, bool $force = false ): array {
+        if ( ! post_type_exists( 'vc_restaurant' ) ) {
+            return [];
+        }
+
+        $this->ensure_terms();
+
+        if ( $force ) {
+            $existing = get_posts([
+                'post_type'   => 'vc_restaurant',
+                'numberposts' => -1,
+                'fields'      => 'ids',
+            ]);
+            foreach ( $existing as $pid ) {
+                wp_delete_post( $pid, true );
+            }
+        }
+
+        $names   = [ 'Cantina da Praça', 'Sushi do Bairro', 'Hamburgueria Fênix', 'Veg & Co', 'Pizzaria La Nonna', 'Sabores do Brasil' ];
+        $created = [];
+
+        for ( $i = 0; $i < $count; $i++ ) {
+            $title = $names[ $i % count( $names ) ] . ' #' . ( $i + 1 );
+            $pid   = wp_insert_post([
+                'post_type'   => 'vc_restaurant',
+                'post_title'  => $title,
+                'post_status' => 'publish',
+                'post_content'=> 'Restaurante de exemplo criado pelo Preenchedor.',
+            ]);
+            if ( is_wp_error( $pid ) || ! $pid ) {
+                continue;
+            }
+
+            // Termos
+            if ( taxonomy_exists( 'vc_cuisine' ) ) {
+                $cuisine = $this->cuisines[ array_rand( $this->cuisines ) ];
+                wp_set_object_terms( $pid, $cuisine, 'vc_cuisine', false );
+            }
+            if ( taxonomy_exists( 'vc_location' ) ) {
+                $location = $this->locations[ array_rand( $this->locations ) ];
+                wp_set_object_terms( $pid, $location, 'vc_location', false );
+            }
+
+            // Metas (compatível com o metabox atual)
+            update_post_meta( $pid, 'vc_restaurant_cnpj', sprintf( '00.000.000/%05d-00', rand( 100, 999 ) ) );
+            update_post_meta( $pid, 'vc_restaurant_whatsapp', '+55 11 9' . rand( 1000, 9999 ) . '-' . rand( 1000, 9999 ) );
+            update_post_meta( $pid, 'vc_restaurant_site', 'https://demo' . ( $i + 1 ) . '.vemcomer.test' );
+            update_post_meta( $pid, 'vc_restaurant_open_hours', 'Seg-Dom 11:00–23:00' );
+            update_post_meta( $pid, 'vc_restaurant_delivery', rand( 0, 1 ) ? '1' : '0' );
+            update_post_meta( $pid, 'vc_restaurant_address', 'Rua Exemplo, ' . rand( 10, 999 ) );
+
+            $created[] = (int) $pid;
+        }
+
+        return $created;
+    }
+
+    /**
+     * Cria itens de cardápio se o CPT existir (opcional).
+     *
+     * @param int $restaurant_id ID do restaurante.
+     * @param int $min           Mínimo de itens.
+     * @param int $max           Máximo de itens.
+     *
+     * @return int[] IDs criados.
+     */
+    public function seed_menu_items_for( int $restaurant_id, int $min = 3, int $max = 6 ): array {
+        if ( ! post_type_exists( 'vc_menu_item' ) ) {
+            return [];
+        }
+
+        $quantity = max( $min, rand( $min, $max ) );
+        $ids      = [];
+
+        for ( $i = 1; $i <= $quantity; $i++ ) {
+            $mid = wp_insert_post([
+                'post_type'   => 'vc_menu_item',
+                'post_title'  => 'Item ' . $restaurant_id . '-' . $i,
+                'post_content'=> 'Descrição do item ' . $i,
+                'post_status' => 'publish',
+            ]);
+            if ( $mid ) {
+                update_post_meta( $mid, '_vc_restaurant_id', $restaurant_id );
+                update_post_meta( $mid, '_vc_price', (string) ( 10 * $i ) . ',00' );
+                update_post_meta( $mid, '_vc_prep_time', (string) ( 5 * $i ) );
+                update_post_meta( $mid, '_vc_is_available', '1' );
+                $ids[] = (int) $mid;
+            }
+        }
+
+        return $ids;
+    }
+}


### PR DESCRIPTION
## Summary
- add a shared VC_Seeder class to centralize restaurant and menu item seeding
- expose the seeder in wp-admin with a "Preenchedor" submenu and optional CSS styling
- reuse the shared seeder in the WP-CLI command and load the submenu from the restaurant bootstrap

## Testing
- php -l inc/seed/Seeder.php
- php -l inc/admin/preenchedor.php
- php -l bin/wp-cli-seed-restaurants.php

------
https://chatgpt.com/codex/tasks/task_b_68df5e9bfc80832bb4ba53bcc2bd610d