### PR TITLE
Add query parameter fallback for restaurant shortcodes

### DIFF
--- a/inc/shortcodes.php
+++ b/inc/shortcodes.php
@@ -1,4 +1,32 @@
 <?php
-if (!defined('ABSPATH')) exit;
+/**
+ * Helpers for shortcode attribute defaults/fallbacks.
+ *
+ * @package VemComerCore
+ */
+
+if ( ! defined( 'ABSPATH' ) ) { exit; }
 
 // Etapas futuras: [vc_explore], [vc_restaurant_menu], [vc_kds], [vc_onboarding], etc.
+
+// [vc_restaurant id="..."] => se "id" não vier, usa ?restaurant_id=
+add_filter( 'shortcode_atts_vc_restaurant', function( $out, $pairs, $atts ) {
+    if ( empty( $out['id'] ) ) {
+        $qs = isset( $_GET['restaurant_id'] ) ? absint( $_GET['restaurant_id'] ) : 0; // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Apenas leitura de parâmetro público.
+        if ( $qs ) {
+            $out['id'] = $qs;
+        }
+    }
+    return $out;
+}, 10, 3 );
+
+// [vc_menu_items restaurant_id="..."] => se "restaurant_id" não vier, usa ?restaurant_id=
+add_filter( 'shortcode_atts_vc_menu_items', function( $out, $pairs, $atts ) {
+    if ( empty( $out['restaurant_id'] ) ) {
+        $qs = isset( $_GET['restaurant_id'] ) ? absint( $_GET['restaurant_id'] ) : 0; // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Apenas leitura de parâmetro público.
+        if ( $qs ) {
+            $out['restaurant_id'] = $qs;
+        }
+    }
+    return $out;
+}, 10, 3 );


### PR DESCRIPTION
## Summary
- allow the `vc_restaurant` shortcode to fall back to the `restaurant_id` query parameter when no `id` is provided
- ensure the `vc_menu_items` shortcode also reuses the `restaurant_id` query parameter when the attribute is absent
- document the shortcode helpers file with a brief header comment

## Testing
- php -l inc/shortcodes.php

------
https://chatgpt.com/codex/tasks/task_b_68dfd623ddb4832ba6deb6b2c972e22d