### PR TITLE
Adjust shortcode defaults to use query fallback

### DIFF
--- a/inc/shortcodes/defaults.php
+++ b/inc/shortcodes/defaults.php
@@ -1,72 +1,31 @@
 <?php
 /**
- * Defaults de atributos para shortcodes do VemComer.
- *
- * Permite fallback via query string (?restaurant_id=123).
+ * Defaults/Fallbacks de atributos para shortcodes.
+ * Permite usar ?restaurant_id=123 na URL quando o atributo não for passado.
  *
  * @package VemComerCore
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-    exit;
-}
+if ( ! defined( 'ABSPATH' ) ) { exit; }
 
-/**
- * Retorna um inteiro positivo da query string.
- *
- * @param string $key Chave na query string.
- * @return string Inteiro positivo como string ou vazio.
- */
-function vc_sc_query_positive_int( string $key ): string {
-    if ( ! isset( $_GET[ $key ] ) ) {
-        return '';
-    }
-
-    $value = absint( wp_unslash( $_GET[ $key ] ) );
-
-    return $value > 0 ? (string) $value : '';
-}
-
-/**
- * Fallback para [vc_restaurant id=""].
- *
- * @param array  $out       Valores atuais.
- * @param array  $pairs     Pares padrões.
- * @param array  $atts      Atributos informados.
- * @param string $shortcode Nome do shortcode.
- * @return array
- */
-function vc_sc_defaults_restaurant( array $out, array $pairs, array $atts, string $shortcode ): array {
+// [vc_restaurant id="..."] => se "id" não vier, usa ?restaurant_id=
+add_filter( 'shortcode_atts_vc_restaurant', function ( $out, $pairs, $atts ) {
     if ( empty( $out['id'] ) ) {
-        $rid = vc_sc_query_positive_int( 'restaurant_id' );
-
-        if ( '' !== $rid ) {
-            $out['id'] = $rid;
+        $qs = isset( $_GET['restaurant_id'] ) ? absint( wp_unslash( $_GET['restaurant_id'] ) ) : 0;
+        if ( $qs ) {
+            $out['id'] = $qs;
         }
     }
-
     return $out;
-}
-add_filter( 'shortcode_atts_vc_restaurant', 'vc_sc_defaults_restaurant', 10, 4 );
+}, 10, 3 );
 
-/**
- * Fallback para [vc_menu_items restaurant_id=""].
- *
- * @param array  $out       Valores atuais.
- * @param array  $pairs     Pares padrões.
- * @param array  $atts      Atributos informados.
- * @param string $shortcode Nome do shortcode.
- * @return array
- */
-function vc_sc_defaults_menu_items( array $out, array $pairs, array $atts, string $shortcode ): array {
-    if ( empty( $out['restaurant_id'] ) ) {
-        $rid = vc_sc_query_positive_int( 'restaurant_id' );
-
-        if ( '' !== $rid ) {
-            $out['restaurant_id'] = $rid;
+// [vc_menu_items restaurant="..."] => se "restaurant" não vier, usa ?restaurant_id=
+add_filter( 'shortcode_atts_vc_menu_items', function ( $out, $pairs, $atts ) {
+    if ( empty( $out['restaurant'] ) ) {
+        $qs = isset( $_GET['restaurant_id'] ) ? absint( wp_unslash( $_GET['restaurant_id'] ) ) : 0;
+        if ( $qs ) {
+            $out['restaurant'] = $qs;
         }
     }
-
     return $out;
-}
-add_filter( 'shortcode_atts_vc_menu_items', 'vc_sc_defaults_menu_items', 10, 4 );
+}, 10, 3 );


### PR DESCRIPTION
## Summary
- simplify shortcode defaults implementation and add query string fallback for restaurant attributes

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68dfed28fc5c832b83d940edb8bc553d